### PR TITLE
ci: auto-build DIY kit zip during deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,19 @@ jobs:
           node-version: 22
           cache: 'npm'
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Pillow (for DIY kit builder)
+        run: pip install Pillow
+
+      - name: Rebuild DIY kit zip
+        # Generates public/KitsunePrints-DIY-Kit.zip from sources, so Vite's
+        # public/ → dist/ copy ships the latest version. Avoids committing a
+        # 47 MB binary blob to git on every kit change.
+        run: python scripts/build_diy_kit.py
+
       - run: npm ci
       - run: npm run build
 

--- a/scripts/build_diy_kit.py
+++ b/scripts/build_diy_kit.py
@@ -8,19 +8,26 @@ as a download).
 
 Run:
     python scripts/build_diy_kit.py
+
+Dependencies:
+    pip install Pillow  (only used to convert atlas .webp → .png on the fly
+                         so the kit ships PNG regardless of what format
+                         public/vanilla/ currently holds)
 """
 
 from __future__ import annotations
 
-import shutil
+import io
 import sys
 import zipfile
 from pathlib import Path
 
+from PIL import Image
+
 ROOT = Path(__file__).resolve().parent.parent
 OUT = ROOT / "public" / "KitsunePrints-DIY-Kit.zip"
 
-# Files the DIY kit needs at its root after extraction.
+# Plain copy-as-is files. (source-relative-to-repo-root, arcname-in-zip)
 INCLUDES = [
     ("scripts/make_pack.py",                  "make_pack.py"),
     ("scripts/README.md",                     "README.md"),
@@ -32,23 +39,55 @@ INCLUDES = [
     ("public/frames/silver.png",              "frames/silver.png"),
     ("public/frames/matte_black.png",         "frames/matte_black.png"),
     ("public/frames/ornate_gold.png",         "frames/ornate_gold.png"),
-    # Vanilla atlases ~ base layers for movie-poster, canvas, and picture-
-    # frame slot compositing. Each atlas is shipped under atlases/<material>.png
-    # so make_pack.py can find them at composite time.
-    ("public/vanilla/_posterMovie_atlas.png",    "atlases/posterMovie.png"),
-    ("public/vanilla/_pictureCanvas1_atlas.png", "atlases/pictureCanvas1.png"),
-    ("public/vanilla/_pictureCanvas2_atlas.png", "atlases/pictureCanvas2.png"),
-    ("public/vanilla/_pictureFramed_atlas.png",  "atlases/pictureFramed.png"),
-    ("public/vanilla/_pictureFramed2_atlas.png", "atlases/pictureFramed2.png"),
-    ("public/vanilla/_pictureFramed3_atlas.png", "atlases/pictureFramed3.png"),
-    ("public/vanilla/_pictureFramed4_atlas.png", "atlases/pictureFramed4.png"),
-    ("public/vanilla/_pictureFramed5_atlas.png", "atlases/pictureFramed5.png"),
-    ("public/vanilla/_pictureFramed6_atlas.png", "atlases/pictureFramed6.png"),
-    ("public/vanilla/_pictureFramed7_atlas.png", "atlases/pictureFramed7.png"),
-    ("public/vanilla/_pictureFramed8_atlas.png", "atlases/pictureFramed8.png"),
     # Example pack
     ("scripts/example_pack/config.json",      "example_pack/config.json"),
 ]
+
+# Vanilla atlas base layers for movie-poster / canvas / picture-frame slot
+# compositing. The web side may store them as .png or .webp (after the
+# perf pass). Either source is loaded via Pillow and shipped as .png in
+# the kit, so make_pack.py can find them at consistent paths regardless
+# of how the web side evolves.
+ATLAS_INCLUDES = [
+    ("_posterMovie_atlas",    "atlases/posterMovie.png"),
+    ("_pictureCanvas1_atlas", "atlases/pictureCanvas1.png"),
+    ("_pictureCanvas2_atlas", "atlases/pictureCanvas2.png"),
+    ("_pictureFramed_atlas",  "atlases/pictureFramed.png"),
+    ("_pictureFramed2_atlas", "atlases/pictureFramed2.png"),
+    ("_pictureFramed3_atlas", "atlases/pictureFramed3.png"),
+    ("_pictureFramed4_atlas", "atlases/pictureFramed4.png"),
+    ("_pictureFramed5_atlas", "atlases/pictureFramed5.png"),
+    ("_pictureFramed6_atlas", "atlases/pictureFramed6.png"),
+    ("_pictureFramed7_atlas", "atlases/pictureFramed7.png"),
+    ("_pictureFramed8_atlas", "atlases/pictureFramed8.png"),
+]
+
+VANILLA_DIR = ROOT / "public" / "vanilla"
+
+
+def find_atlas_source(stem: str) -> Path:
+    """Locate an atlas source by stem, preferring .webp then .png. The web
+    side may have either format depending on whether the perf optimization
+    PR has merged. We accept either and normalize to PNG inside the kit."""
+    for ext in (".webp", ".png"):
+        candidate = VANILLA_DIR / f"{stem}{ext}"
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError(
+        f"No atlas source found for stem '{stem}' in {VANILLA_DIR} "
+        f"(tried .webp and .png)"
+    )
+
+
+def load_atlas_as_png_bytes(src: Path) -> bytes:
+    """Load an atlas (any Pillow-readable format) and return PNG bytes."""
+    buf = io.BytesIO()
+    with Image.open(src) as img:
+        # Preserve alpha if present.
+        if img.mode not in ("RGBA", "RGB"):
+            img = img.convert("RGBA" if "A" in img.mode else "RGB")
+        img.save(buf, format="PNG", optimize=True)
+    return buf.getvalue()
 
 
 def main() -> None:
@@ -59,15 +98,32 @@ def main() -> None:
             print(f"  - {m}")
         sys.exit(1)
 
+    # Resolve atlas sources up-front so we fail loudly before zipping.
+    atlas_sources: list[tuple[Path, str]] = []
+    for stem, arcname in ATLAS_INCLUDES:
+        try:
+            src = find_atlas_source(stem)
+        except FileNotFoundError as e:
+            print(f"ERROR: {e}")
+            sys.exit(1)
+        atlas_sources.append((src, arcname))
+
     OUT.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(OUT, "w", zipfile.ZIP_DEFLATED) as zf:
+        # Plain copies
         for src, arcname in INCLUDES:
             zf.write(ROOT / src, f"KitsunePrints-DIY-Kit/{arcname}")
+
+        # Atlases: load via Pillow (handles .webp + .png), write PNG bytes
+        for src, arcname in atlas_sources:
+            png_bytes = load_atlas_as_png_bytes(src)
+            zf.writestr(f"KitsunePrints-DIY-Kit/{arcname}", png_bytes)
+
         # Empty images/ folder marker so example_pack runs out of the box
         zf.writestr("KitsunePrints-DIY-Kit/example_pack/images/.gitkeep", "")
 
-    size_kb = OUT.stat().st_size / 1024
-    print(f"OK Built DIY kit: {OUT.relative_to(ROOT)} ({size_kb:.1f} KB)")
+    size_mb = OUT.stat().st_size / 1024 / 1024
+    print(f"OK Built DIY kit: {OUT.relative_to(ROOT)} ({size_mb:.1f} MB)")
     print(f"   Served at https://prints.kitsuneden.net/{OUT.name}")
 
 


### PR DESCRIPTION
## Why
\`https://prints.kitsuneden.net/KitsunePrints-DIY-Kit.zip\` was returning Caddy's SPA fallback (\`index.html\`) instead of the actual kit. Reason: the zip was on Ada's local disk but not tracked in git, so the deploy CI never built or shipped it.

## What
Have CI regenerate the kit from sources during deploy, before \`npm run build\`. Vite's \`public/\` → \`dist/\` copy ships the rebuilt zip, then rsync deploys it. No 47 MB binary lives in git history.

**Workflow:**
- Add \`actions/setup-python@v5\` (3.12)
- \`pip install Pillow\`
- \`python scripts/build_diy_kit.py\` before \`npm run build\`

**\`build_diy_kit.py\`:**
- Auto-detect atlas extension (\`.webp\` or \`.png\`) so it survives PR #6 (vanilla atlas WebP conversion). Tries \`.webp\` first, falls back to \`.png\`.
- Load atlases via Pillow and write PNG bytes into the kit zip ~ the kit's \`atlases/\` folder always ships \`.png\` regardless of source format, matching \`make_pack.py\` expectations.
- Verified locally: kit builds cleanly to 47.6 MB.

## Test plan
- [ ] After merge, the deploy workflow runs and adds the kit-build step
- [ ] \`curl -I https://prints.kitsuneden.net/KitsunePrints-DIY-Kit.zip\` returns \`Content-Type: application/zip\` (not \`text/html\`) and ~47 MB content-length
- [ ] Download + unzip the live file, run \`python make_pack.py example_pack/\` against it, confirm modlet builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)