### PR TITLE
slot cards: show dimensions + 3-per-row snack posters

### DIFF
--- a/src/components/SlotCard.tsx
+++ b/src/components/SlotCard.tsx
@@ -45,6 +45,35 @@ function pickPreviewAspectClass(slot: SlotDef): string {
   return 'aspect-square'
 }
 
+/**
+ * Describe a slot's expected image dimensions in human-friendly form. Shown
+ * as a tiny caption in the slot header so users know what aspect to crop /
+ * what pixel size makes sense before uploading.
+ *
+ * Returns text like "3:4 portrait · 1024×1024" or "1:1 square · 1024×1024".
+ * For atlas-tile slots, includes the actual tile pixel dimensions ~ that's
+ * what the user's image will get composited into.
+ */
+function describeSlotDimensions(slot: SlotDef): string {
+  if (slot.kind === 'portrait') return '3:4 portrait · 1024×1024'
+  if (slot.kind === 'abstract') return '1:1 square · 1024×1024'
+  if (slot.kind === 'decor') return '1:1 square · 1024×1024'
+  if ((slot.kind === 'moviePoster' || slot.kind === 'canvasTile') && slot.atlasTile) {
+    const { w, h } = slot.atlasTile
+    return `${aspectName(w, h)} · ${w}×${h}`
+  }
+  return ''
+}
+
+function aspectName(w: number, h: number): string {
+  const r = w / h
+  if (Math.abs(r - 0.75) < 0.05) return '3:4 portrait'
+  if (Math.abs(r - 1) < 0.05) return '1:1 square'
+  if (Math.abs(r - 4 / 3) < 0.05) return '4:3'
+  if (Math.abs(r - 16 / 9) < 0.05) return '16:9 wide'
+  return r < 1 ? `${(Math.round((1 / r) * 100) / 100)}:1 tall` : `${(Math.round(r * 100) / 100)}:1 wide`
+}
+
 export function SlotCard({ slot, state, onChange }: Props) {
   const fileRef = useRef<HTMLInputElement>(null)
   // When non-null, we're showing the crop dialog for this URL.
@@ -120,6 +149,9 @@ export function SlotCard({ slot, state, onChange }: Props) {
             <h3 className="font-medium truncate">{slot.label}</h3>
             <div className="text-xs text-zinc-500 truncate">
               replacing <code className="text-zinc-400">{slot.slotId}</code>
+            </div>
+            <div className="text-[11px] text-zinc-600 mt-0.5 truncate">
+              {describeSlotDimensions(slot)}
             </div>
           </div>
         </div>

--- a/src/pages/BuilderPage.tsx
+++ b/src/pages/BuilderPage.tsx
@@ -79,7 +79,7 @@ const SLOT_TABS: SlotTabDef[] = [
     blurb:
       'The 17-poster snack-shop wall of fame ~ Thick Nick\'s Jerky, Goblin-O\'s, Atom Junkies, Health Bar, the lot. Each has its own material so they swap independently. The reference thumb shows the vanilla art for that slot.',
     filter: (s) => s.kind === 'decor' && s.slotId.startsWith('signSnackPoster'),
-    gridCols: 'grid-cols-2 md:grid-cols-4 xl:grid-cols-5',
+    gridCols: 'grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
   },
 ]
 


### PR DESCRIPTION
## What

Two UX nudges:

**1. Snack Posters grid**: was \`2 / 4 / 5\` cols, felt cramped, especially with the new dimension caption. Now \`1 / 2 / 3\` matching Frames + Canvases.

**2. Dimension caption on every slot card** ~ a small subcaption under the slot ID showing expected image dimensions:

- Portraits: \`3:4 portrait · 1024×1024\`
- Abstracts / Decor: \`1:1 square · 1024×1024\`
- Movie posters / Canvases / Frames: aspect name + actual atlas tile pixels, e.g. \`3:4 portrait · 347×483\`

For atlas-tile slots the dimension is the [b]actual tile size[/b] the user's image gets composited into ~ useful for picking source images that won't get aggressively scaled.

## Why this is small but valuable
The cropper already enforces the right aspect, so users don't NEED dimension info to succeed. But seeing "3:4 portrait" before uploading saves a "wait, what shape is this?" moment ~ especially for atlas tiles where the aspect varies per slot.

## Test plan
- [ ] Open the builder, eyeball each tab ~ dimension caption renders cleanly without truncating in any column count
- [ ] Snack Posters tab: now 3 per row at desktop, 2 at tablet, 1 at mobile
- [ ] No tests broke (43/43 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)