### PR TITLE
fix: slot dimension caption respects atlasTile (snack posters were all wrong)

### DIFF
--- a/src/components/SlotCard.tsx
+++ b/src/components/SlotCard.tsx
@@ -55,22 +55,33 @@ function pickPreviewAspectClass(slot: SlotDef): string {
  * what the user's image will get composited into.
  */
 function describeSlotDimensions(slot: SlotDef): string {
-  if (slot.kind === 'portrait') return '3:4 portrait · 1024×1024'
-  if (slot.kind === 'abstract') return '1:1 square · 1024×1024'
-  if (slot.kind === 'decor') return '1:1 square · 1024×1024'
-  if ((slot.kind === 'moviePoster' || slot.kind === 'canvasTile') && slot.atlasTile) {
+  // atlasTile is the most specific source of truth ~ it's the actual pixel
+  // region the user's image will composite into (or, for decor slots that
+  // share a vanilla atlas, the block aspect their image will stretch to
+  // fill at runtime). Check it first regardless of kind.
+  //
+  // Important callout: snack-poster decor slots have atlasTile data even
+  // though they're kind:'decor' ~ Health Bar (wide) is 1638×512 (~3:1),
+  // most others are 410×512 (~4:5). Without this branch, all decor slots
+  // showed "1:1 square · 1024×1024" which was wrong for ~all 17.
+  if (slot.atlasTile) {
     const { w, h } = slot.atlasTile
     return `${aspectName(w, h)} · ${w}×${h}`
   }
+  if (slot.kind === 'portrait') return '3:4 portrait · 1024×1024'
+  if (slot.kind === 'abstract') return '1:1 square · 1024×1024'
+  if (slot.kind === 'decor') return '1:1 square · 1024×1024'
   return ''
 }
 
 function aspectName(w: number, h: number): string {
   const r = w / h
   if (Math.abs(r - 0.75) < 0.05) return '3:4 portrait'
+  if (Math.abs(r - 0.8) < 0.05) return '4:5 tall'
   if (Math.abs(r - 1) < 0.05) return '1:1 square'
   if (Math.abs(r - 4 / 3) < 0.05) return '4:3'
   if (Math.abs(r - 16 / 9) < 0.05) return '16:9 wide'
+  if (r >= 2.5) return `~${Math.round(r)}:1 wide`
   return r < 1 ? `${(Math.round((1 / r) * 100) / 100)}:1 tall` : `${(Math.round(r * 100) / 100)}:1 wide`
 }
 


### PR DESCRIPTION
## What
Followup to PR #8. The dimension caption was checking \`kind\` first and ignoring \`atlasTile\` for decor slots, so the 17 snack posters all displayed \`1:1 square · 1024×1024\` regardless of their actual dimensions.

Real shapes after this fix:

| Slot | Was showing | Now shows |
|---|---|---|
| Snack ~ Health Bar (wide) | \`1:1 square · 1024×1024\` | \`~3:1 wide · 1638×512\` |
| Snack ~ Fort Bites | \`1:1 square · 1024×1024\` | \`4:5 tall · 410×512\` |
| Snack ~ Atom Junkies | \`1:1 square · 1024×1024\` | \`4:5 tall · 410×512\` |
| ...and 14 other snack posters | wrong | now correct |

## Fix
Check \`slot.atlasTile\` before \`slot.kind\` in the helper. atlasTile is the most specific source of truth ~ it's the actual block aspect the user's image stretches to fill at runtime. For slots without atlasTile (calendar, blueprints, target posters), fall back to the kind-based defaults.

Also expanded \`aspectName()\` to recognize \`4:5 tall\` (most snack tiles) and \`~N:1 wide\` (the Health Bar outlier).

## Test plan
- [ ] Open Snack Posters tab on builder, verify each card now shows the correct aspect/pixel caption
- [ ] Movie posters, frames, canvases unchanged (they were already using atlasTile via the second branch of the old helper)
- [ ] Standalone decor slots (calendar, blueprints, targets) still show \`1:1 square · 1024×1024\`
- [ ] All 43 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)