### PR TITLE
fix: canvas atlas tile coords (real bug report ~ 7-of-10 swapped)

### DIFF
--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -232,16 +232,24 @@ export const SLOTS: SlotDef[] = [
   // Per-prefab slots so users can replace each canvas independently. Composer
   // batches by materialName and writes a single composite atlas per material;
   // mesh UVs do the per-block tile selection.
-  { slotId: 'pictureCanvas_01a', materialName: 'pictureCanvas1', label: 'Canvas A (atlas 1)', vanillaBlocks: ['pictureCanvas_01a'], kind: 'canvasTile', atlasTile: { x: 1024, y: 273,  w: 1024, h: 590 } },
+  //
+  // Coords corrected after a real-world bug report: a user uploaded to all
+  // 10 canvases and got back a deterministic permutation (A→D→F 3-cycle,
+  // E↔I swap, G↔J swap; B/C/H landed correctly). The label-to-coord
+  // mapping in this file had been assigned visually from the vanilla atlas
+  // image and didn't match what each pictureCanvas_01<letter> block actually
+  // samples in-game. Coords below are reverse-derived from that bug report
+  // and reflect each block's true UV region.
+  { slotId: 'pictureCanvas_01a', materialName: 'pictureCanvas1', label: 'Canvas A (atlas 1)', vanillaBlocks: ['pictureCanvas_01a'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
   { slotId: 'pictureCanvas_01b', materialName: 'pictureCanvas1', label: 'Canvas B (atlas 1)', vanillaBlocks: ['pictureCanvas_01b'], kind: 'canvasTile', atlasTile: { x: 0,    y: 863,  w: 1024, h: 593 } },
   { slotId: 'pictureCanvas_01c', materialName: 'pictureCanvas1', label: 'Canvas C (atlas 1)', vanillaBlocks: ['pictureCanvas_01c'], kind: 'canvasTile', atlasTile: { x: 1024, y: 863,  w: 1024, h: 593 } },
-  { slotId: 'pictureCanvas_01d', materialName: 'pictureCanvas1', label: 'Canvas D (atlas 1)', vanillaBlocks: ['pictureCanvas_01d'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
-  { slotId: 'pictureCanvas_01f', materialName: 'pictureCanvas1', label: 'Canvas F (atlas 1)', vanillaBlocks: ['pictureCanvas_01f'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
-  { slotId: 'pictureCanvas_01e', materialName: 'pictureCanvas2', label: 'Canvas E (atlas 2)', vanillaBlocks: ['pictureCanvas_01e'], kind: 'canvasTile', atlasTile: { x: 1024, y: 273,  w: 1024, h: 590 } },
-  { slotId: 'pictureCanvas_01g', materialName: 'pictureCanvas2', label: 'Canvas G (atlas 2)', vanillaBlocks: ['pictureCanvas_01g'], kind: 'canvasTile', atlasTile: { x: 0,    y: 863,  w: 1024, h: 593 } },
+  { slotId: 'pictureCanvas_01d', materialName: 'pictureCanvas1', label: 'Canvas D (atlas 1)', vanillaBlocks: ['pictureCanvas_01d'], kind: 'canvasTile', atlasTile: { x: 1024, y: 273,  w: 1024, h: 590 } },
+  { slotId: 'pictureCanvas_01f', materialName: 'pictureCanvas1', label: 'Canvas F (atlas 1)', vanillaBlocks: ['pictureCanvas_01f'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
+  { slotId: 'pictureCanvas_01e', materialName: 'pictureCanvas2', label: 'Canvas E (atlas 2)', vanillaBlocks: ['pictureCanvas_01e'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
+  { slotId: 'pictureCanvas_01g', materialName: 'pictureCanvas2', label: 'Canvas G (atlas 2)', vanillaBlocks: ['pictureCanvas_01g'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
   { slotId: 'pictureCanvas_01h', materialName: 'pictureCanvas2', label: 'Canvas H (atlas 2)', vanillaBlocks: ['pictureCanvas_01h'], kind: 'canvasTile', atlasTile: { x: 1024, y: 863,  w: 1024, h: 593 } },
-  { slotId: 'pictureCanvas_01i', materialName: 'pictureCanvas2', label: 'Canvas I (atlas 2)', vanillaBlocks: ['pictureCanvas_01i'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
-  { slotId: 'pictureCanvas_01j', materialName: 'pictureCanvas2', label: 'Canvas J (atlas 2)', vanillaBlocks: ['pictureCanvas_01j'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
+  { slotId: 'pictureCanvas_01i', materialName: 'pictureCanvas2', label: 'Canvas I (atlas 2)', vanillaBlocks: ['pictureCanvas_01i'], kind: 'canvasTile', atlasTile: { x: 1024, y: 273,  w: 1024, h: 590 } },
+  { slotId: 'pictureCanvas_01j', materialName: 'pictureCanvas2', label: 'Canvas J (atlas 2)', vanillaBlocks: ['pictureCanvas_01j'], kind: 'canvasTile', atlasTile: { x: 0,    y: 863,  w: 1024, h: 593 } },
 ]
 
 export interface SlotState {


### PR DESCRIPTION
## The bug report
User: *"I made changes to 10 items in the [Canvas] section, but the images I uploaded were swapped with other images. Canvas A → Canvas D, Canvas D → Canvas F, Canvas E → Canvas I, Canvas F → Canvas A, Canvas G → Canvas J, Canvas I → Canvas E, Canvas J → Canvas G. Thumbnails and titles are correct."*

## Decoded
Pattern is deterministic, not random:
- **A → D → F → A** (3-cycle on atlas 1)
- **E ↔ I** (swap on atlas 2)
- **G ↔ J** (swap on atlas 2)
- B, C, H landed correctly

That permutation is too specific to be misobservation. It only happens if our \`atlasTile\` coords were assigned to the wrong tile positions ~ the slot label said "A" but the coord pointed at where D actually lives in the vanilla atlas (and so on through the cycle).

## The fix
Reverse-derive the correct coords from the bug report. 7 slots updated, 3 (B, C, H) confirmed already correct.

| Slot | Was | Now |
|---|---|---|
| A | (1024, 273) | (1024, 1456) |
| D | (0, 1456) | (1024, 273) |
| F | (1024, 1456) | (0, 1456) |
| E | (1024, 273) | (0, 1456) |
| G | (0, 863) | (1024, 1456) |
| I | (0, 1456) | (1024, 273) |
| J | (1024, 1456) | (0, 863) |

## Test plan
- [ ] Deploy, rebuild a 10-canvas test pack via the web tool, confirm each in-game canvas block shows the correct user image (no swaps)
- [ ] Existing user: rebuild from web tool, confirm swap is gone
- [ ] Reply to the bug reporter with the deploy ETA

## Followup
Write \`scripts/read_canvas_uvs.py\` (analogous to \`read_picture_frame_uvs.py\`) that reads \`pictureCanvas_01*\` prefab LOD0 mesh UVs directly from game data, so future categories don't rely on visual atlas labeling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)