### PR TITLE
fix: invert canvas A/D/F 3-cycle (PR #11 had direction backwards)

### DIFF
--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -240,11 +240,11 @@ export const SLOTS: SlotDef[] = [
   // image and didn't match what each pictureCanvas_01<letter> block actually
   // samples in-game. Coords below are reverse-derived from that bug report
   // and reflect each block's true UV region.
-  { slotId: 'pictureCanvas_01a', materialName: 'pictureCanvas1', label: 'Canvas A (atlas 1)', vanillaBlocks: ['pictureCanvas_01a'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
+  { slotId: 'pictureCanvas_01a', materialName: 'pictureCanvas1', label: 'Canvas A (atlas 1)', vanillaBlocks: ['pictureCanvas_01a'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
   { slotId: 'pictureCanvas_01b', materialName: 'pictureCanvas1', label: 'Canvas B (atlas 1)', vanillaBlocks: ['pictureCanvas_01b'], kind: 'canvasTile', atlasTile: { x: 0,    y: 863,  w: 1024, h: 593 } },
   { slotId: 'pictureCanvas_01c', materialName: 'pictureCanvas1', label: 'Canvas C (atlas 1)', vanillaBlocks: ['pictureCanvas_01c'], kind: 'canvasTile', atlasTile: { x: 1024, y: 863,  w: 1024, h: 593 } },
-  { slotId: 'pictureCanvas_01d', materialName: 'pictureCanvas1', label: 'Canvas D (atlas 1)', vanillaBlocks: ['pictureCanvas_01d'], kind: 'canvasTile', atlasTile: { x: 1024, y: 273,  w: 1024, h: 590 } },
-  { slotId: 'pictureCanvas_01f', materialName: 'pictureCanvas1', label: 'Canvas F (atlas 1)', vanillaBlocks: ['pictureCanvas_01f'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
+  { slotId: 'pictureCanvas_01d', materialName: 'pictureCanvas1', label: 'Canvas D (atlas 1)', vanillaBlocks: ['pictureCanvas_01d'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
+  { slotId: 'pictureCanvas_01f', materialName: 'pictureCanvas1', label: 'Canvas F (atlas 1)', vanillaBlocks: ['pictureCanvas_01f'], kind: 'canvasTile', atlasTile: { x: 1024, y: 273,  w: 1024, h: 590 } },
   { slotId: 'pictureCanvas_01e', materialName: 'pictureCanvas2', label: 'Canvas E (atlas 2)', vanillaBlocks: ['pictureCanvas_01e'], kind: 'canvasTile', atlasTile: { x: 0,    y: 1456, w: 1024, h: 592 } },
   { slotId: 'pictureCanvas_01g', materialName: 'pictureCanvas2', label: 'Canvas G (atlas 2)', vanillaBlocks: ['pictureCanvas_01g'], kind: 'canvasTile', atlasTile: { x: 1024, y: 1456, w: 1024, h: 592 } },
   { slotId: 'pictureCanvas_01h', materialName: 'pictureCanvas2', label: 'Canvas H (atlas 2)', vanillaBlocks: ['pictureCanvas_01h'], kind: 'canvasTile', atlasTile: { x: 1024, y: 863,  w: 1024, h: 593 } },


### PR DESCRIPTION
## What
PR #11 fixed 7 of 10 canvas atlas tile coords ~ but the 3-cycle (A↔D↔F) ended up rotated the wrong direction. User confirmed by re-testing post-merge:

> *"D → F"*  
> *"A → D"*

Same pattern as the original report. The 2-cycles (E↔I, G↔J) are unaffected because both interpretations of the bug-report English produce the same fix for swaps; only the 3-cycle is direction-dependent.

## Fix
Invert just A, D, F:

| Slot | Was (after #11) | Now |
|---|---|---|
| A | (1024, 1456) | (0, 1456) |
| D | (1024, 273) | (1024, 1456) |
| F | (0, 1456) | (1024, 273) |

B, C, H, E, G, I, J stay where #11 left them.

## Lesson learned for future
Bug-report English like "X → Y" can mean "X's content went to Y" OR "X is now showing Y's content" ~ for 3-cycles those are inverses. Should have asked the reporter to disambiguate before shipping #11. Followup tracked: write \`read_canvas_uvs.py\` analogous to \`read_picture_frame_uvs.py\` so we ground-truth from prefab mesh UVs instead of decoding ambiguous user reports.

## Test plan
- [ ] After deploy, build a fresh test pack with all 10 canvases
- [ ] Verify each block shows its own uploaded image (no swaps)
- [ ] Reply to the bug reporter with the post-#11+#12 deploy ETA

🤖 Generated with [Claude Code](https://claude.com/claude-code)