### PR TITLE
fix snack poster UV mismatch + rebuild frame picker preview

### DIFF
--- a/src/components/FramePresetPicker.tsx
+++ b/src/components/FramePresetPicker.tsx
@@ -1,40 +1,95 @@
-import { FRAME_PRESETS } from '../types/slots'
+import { useEffect, useRef } from 'react'
+import { FRAME_PRESETS, type SlotDef } from '../types/slots'
+import { drawSwatchInto } from '../utils/livePreview'
 
 interface Props {
+  slot: SlotDef
   selectedId: string
   onChange: (id: string) => void
 }
 
-export function FramePresetPicker({ selectedId, onChange }: Props) {
+/**
+ * Frame tint picker. Each swatch shows a fixed wood-region crop from the
+ * current slot's vanilla atlas, multiply-tinted with that preset's hex.
+ * What you see in the swatch is the same wood grain that ships in the
+ * modlet ~ just at picker resolution.
+ *
+ * Slot-aware so cross-atlas wood pattern variation is honest (Frame A's
+ * pictureFramed atlas has different grain than Frame P's pictureFramed6).
+ * Slot-tile-agnostic so the six swatches in any one picker share an atlas
+ * and read as a tint-family comparison.
+ */
+export function FramePresetPicker({ slot, selectedId, onChange }: Props) {
   return (
     <div>
       <div className="text-xs text-zinc-500 mb-2">Frame</div>
       <div className="grid grid-cols-3 gap-2">
-        {FRAME_PRESETS.map(preset => {
-          const selected = preset.id === selectedId
-          return (
-            <button
-              key={preset.id}
-              type="button"
-              onClick={() => onChange(preset.id)}
-              className={`relative rounded overflow-hidden border-2 transition-colors ${
-                selected ? 'border-orange-500' : 'border-zinc-800 hover:border-zinc-600'
-              }`}
-              title={preset.label}
-            >
-              <img
-                src={preset.imagePath}
-                alt={preset.label}
-                className="w-full h-12 object-cover"
-                style={{ objectPosition: 'center' }}
-              />
-              <div className="absolute inset-x-0 bottom-0 bg-black/70 text-[10px] text-zinc-300 px-1 py-0.5 truncate">
-                {preset.label}
-              </div>
-            </button>
-          )
-        })}
+        {FRAME_PRESETS.map(preset => (
+          <SwatchButton
+            key={preset.id}
+            slot={slot}
+            presetId={preset.id}
+            label={preset.label}
+            selected={preset.id === selectedId}
+            onClick={() => onChange(preset.id)}
+          />
+        ))}
       </div>
     </div>
+  )
+}
+
+interface SwatchButtonProps {
+  slot: SlotDef
+  presetId: string
+  label: string
+  selected: boolean
+  onClick: () => void
+}
+
+// Render-resolution for the swatch canvas backing store. CSS sizes the
+// element to fill the grid cell; this is the bitmap resolution it draws at.
+const SWATCH_PX = 160
+
+function SwatchButton({ slot, presetId, label, selected, onClick }: SwatchButtonProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    let cancelled = false
+    drawSwatchInto(canvas, slot, presetId).catch(() => {
+      // Swallow ~ a failed swatch draw shows a blank canvas, which is a
+      // mild degradation, not a crash. The preset still functions on click.
+    }).then(() => {
+      if (cancelled) return
+    })
+    return () => { cancelled = true }
+  }, [slot, presetId])
+
+  // Selected ring uses a stronger border color + outline (zero layout cost),
+  // not a thicker border. Keeps swatches from jumping when selection changes.
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      className={`relative rounded overflow-hidden border transition-colors outline-none ${
+        selected
+          ? 'border-orange-500 outline outline-2 outline-orange-500/60 outline-offset-[-2px]'
+          : 'border-zinc-800 hover:border-zinc-600'
+      }`}
+    >
+      <canvas
+        ref={canvasRef}
+        width={SWATCH_PX}
+        height={SWATCH_PX}
+        className="block w-full h-12 object-cover"
+        aria-label={label}
+      />
+      <div className="absolute inset-x-0 bottom-0 bg-black/70 text-[10px] text-zinc-300 px-1 py-0.5 truncate">
+        {label}
+      </div>
+    </button>
   )
 }

--- a/src/components/SlotCard.tsx
+++ b/src/components/SlotCard.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { SlotDef, SlotState } from '../types/slots'
-import { DEFAULT_FRAME_PRESET_ID } from '../types/slots'
+import { ATLAS_SOURCES, DEFAULT_FRAME_PRESET_ID } from '../types/slots'
 import { CropDialog } from './CropDialog'
 import { FramePresetPicker } from './FramePresetPicker'
+import { drawSlotPreviewInto } from '../utils/livePreview'
 
 interface Props {
   slot: SlotDef
@@ -18,6 +19,33 @@ interface Props {
  *   - 0.85..1.2       -> 1:1 square   (w-12 h-12)
  *   - > 1.2           -> 16:9 wide    (w-16 h-9)
  */
+/**
+ * Compute the slot's "visible" aspect ratio + pixel dimensions ~ what the
+ * user actually sees in-game.
+ *
+ * For decor slots with a meshUvBbox, the mesh samples only a sub-region of
+ * the output texture (e.g. Bretzels samples UV 0,0->0.5,1, so visible is
+ * 1021x2048 not the 410x512 atlasTile). For those slots the bbox is the
+ * source of truth ~ atlasTile is just where the vanilla art lived in the
+ * shared atlas, which has nothing to do with the in-game block aspect.
+ *
+ * For everything else, fall back to atlasTile dimensions, or kind-based
+ * defaults for portrait/abstract.
+ */
+const UV_BBOX_OUTPUT_SIZE = 2048
+
+function getVisibleDims(slot: SlotDef): { w: number; h: number } | null {
+  if (slot.meshUvBbox) {
+    const { l, t, r, b } = slot.meshUvBbox
+    const w = Math.round((r - l) * UV_BBOX_OUTPUT_SIZE)
+    const h = Math.round((b - t) * UV_BBOX_OUTPUT_SIZE)
+    return { w, h }
+  }
+  if (slot.atlasTile) return { w: slot.atlasTile.w, h: slot.atlasTile.h }
+  if (slot.kind === 'portrait') return { w: 3, h: 4 } // ratio only
+  return null // abstract / standalone decor: square fallback
+}
+
 function pickThumbClass(slot: SlotDef): string {
   if (slot.kind === 'portrait' || slot.kind === 'moviePoster') return 'w-9 h-12'
   if (slot.kind === 'decor') return 'w-10 h-12 object-contain'
@@ -41,10 +69,11 @@ function pickThumbClass(slot: SlotDef): string {
  * the crop frame shape stay in sync per slot.
  */
 function getSlotAspectRatio(slot: SlotDef): string {
+  // Drop zone uses the actually-visible aspect (meshUvBbox if present,
+  // else atlasTile, else portrait/square defaults).
   if (slot.kind === 'portrait') return '3 / 4'
-  if (slot.atlasTile) {
-    return `${slot.atlasTile.w} / ${slot.atlasTile.h}`
-  }
+  const dims = getVisibleDims(slot)
+  if (dims) return `${dims.w} / ${dims.h}`
   return '1 / 1'
 }
 
@@ -58,20 +87,16 @@ function getSlotAspectRatio(slot: SlotDef): string {
  * what the user's image will get composited into.
  */
 function describeSlotDimensions(slot: SlotDef): string {
-  // atlasTile is the most specific source of truth ~ it's the actual pixel
-  // region the user's image will composite into (or, for decor slots that
-  // share a vanilla atlas, the block aspect their image will stretch to
-  // fill at runtime). Check it first regardless of kind.
-  //
-  // Important callout: snack-poster decor slots have atlasTile data even
-  // though they're kind:'decor' ~ Health Bar (wide) is 1638×512 (~3:1),
-  // most others are 410×512 (~4:5). Without this branch, all decor slots
-  // showed "1:1 square · 1024×1024" which was wrong for ~all 17.
-  if (slot.atlasTile) {
-    const { w, h } = slot.atlasTile
-    return `${aspectName(w, h)} · ${w}×${h}`
+  // Visible region is the source of truth for what to crop to. For snack
+  // posters and other meshUvBbox slots, that's the bbox-derived dimensions;
+  // for everything else, atlasTile or kind-based defaults.
+  const dims = getVisibleDims(slot)
+  if (dims) {
+    // Portrait kind uses ratio-only dims (3:4) ~ format with the canonical
+    // 1024×1024 source size since that's what the composer outputs for portraits.
+    if (slot.kind === 'portrait') return '3:4 portrait · 1024×1024'
+    return `${aspectName(dims.w, dims.h)} · ${dims.w}×${dims.h}`
   }
-  if (slot.kind === 'portrait') return '3:4 portrait · 1024×1024'
   if (slot.kind === 'abstract') return '1:1 square · 1024×1024'
   if (slot.kind === 'decor') return '1:1 square · 1024×1024'
   return ''
@@ -88,6 +113,35 @@ function aspectName(w: number, h: number): string {
   return r < 1 ? `${(Math.round((1 / r) * 100) / 100)}:1 tall` : `${(Math.round(r * 100) / 100)}:1 wide`
 }
 
+/**
+ * True if this slot should render the live atlas-composited preview in its
+ * drop zone. Picture frames (and any other shared-atlas tile slot with a
+ * frame tint zone) qualify ~ for those, the user picks a tint and we can
+ * show what the wood will actually look like. Other slots fall back to the
+ * straight image preview.
+ *
+ * The check needs ATLAS_SOURCES + atlasTile so the live preview helper has
+ * something to crop, AND a frame tint capability so picking presets means
+ * something here. Slots without frameTintHeightPct (e.g. movie posters,
+ * picture canvases) just show the image.
+ */
+function slotHasLiveFramePreview(slot: SlotDef): boolean {
+  if (!slot.atlasTile) return false
+  const source = ATLAS_SOURCES[slot.materialName]
+  return Boolean(source?.frameTintHeightPct)
+}
+
+/**
+ * Frame-tint slots that show the picker. Currently the pictureFrame_01<letter>
+ * family ~ those samples on a wood-frame atlas with a real tint zone. Kept
+ * as a function so the rule can grow without re-touching the JSX.
+ */
+function slotShowsFramePicker(slot: SlotDef): boolean {
+  if (slot.kind === 'portrait') return true
+  if (slot.kind === 'canvasTile' && slot.slotId.startsWith('pictureFrame_01')) return true
+  return false
+}
+
 export function SlotCard({ slot, state, onChange }: Props) {
   const fileRef = useRef<HTMLInputElement>(null)
   // When non-null, we're showing the crop dialog for this URL.
@@ -101,10 +155,15 @@ export function SlotCard({ slot, state, onChange }: Props) {
   //     Health Bar an outlier at 1638×512 (~3:1 wide).
   //   - everything else (abstracts, standalone decor): square. The DLL
   //     resets UV scale to fill the canvas so square-cropped works.
-  const aspect =
-    slot.kind === 'portrait' ? 3 / 4
-    : slot.atlasTile ? slot.atlasTile.w / slot.atlasTile.h
-    : 1
+  // Cropper aspect: same source as the drop-zone shape, so cropping
+  // matches the shape of the in-game visible region. snack posters get
+  // their meshUvBbox aspect; other slots fall back to atlasTile/portrait.
+  const aspect = (() => {
+    if (slot.kind === 'portrait') return 3 / 4
+    const dims = getVisibleDims(slot)
+    if (dims) return dims.w / dims.h
+    return 1
+  })()
 
   function handleFile(file: File) {
     // Stash the original as an object URL and open the cropper.
@@ -193,7 +252,14 @@ export function SlotCard({ slot, state, onChange }: Props) {
           className="bg-zinc-950 border-2 border-dashed border-zinc-700 rounded cursor-pointer flex items-center justify-center overflow-hidden hover:border-zinc-500 transition-colors"
           style={{ aspectRatio: getSlotAspectRatio(slot) }}
         >
-          {state.preview ? (
+          {slotHasLiveFramePreview(slot) ? (
+            <LiveSlotPreview
+              slot={slot}
+              file={state.file}
+              framePresetId={state.framePresetId || DEFAULT_FRAME_PRESET_ID}
+              hasImage={Boolean(state.preview)}
+            />
+          ) : state.preview ? (
             <img src={state.preview} alt={slot.label} className="w-full h-full object-cover" />
           ) : (
             <div className="text-center text-zinc-600 px-4">
@@ -216,26 +282,20 @@ export function SlotCard({ slot, state, onChange }: Props) {
           }}
         />
 
-        {slot.kind === 'portrait' && (
+        {slotShowsFramePicker(slot) && (
           <div className="mt-3">
             <FramePresetPicker
+              slot={slot}
               selectedId={state.framePresetId || DEFAULT_FRAME_PRESET_ID}
               onChange={(id) => onChange({ ...state, framePresetId: id })}
             />
-          </div>
-        )}
-
-        {slot.kind === 'canvasTile' && slot.slotId.startsWith('pictureFrame_01') && (
-          <div className="mt-3">
-            <FramePresetPicker
-              selectedId={state.framePresetId || DEFAULT_FRAME_PRESET_ID}
-              onChange={(id) => onChange({ ...state, framePresetId: id })}
-            />
-            <p className="mt-1 text-[10px] text-zinc-600 leading-tight">
-              Wood frame tint ~ shared with sibling frames in this style group
-              (vanilla atlas means letters in the same atlas all share the
-              wood region).
-            </p>
+            {slot.kind === 'canvasTile' && (
+              <p className="mt-1 text-[10px] text-zinc-600 leading-tight">
+                Wood frame tint ~ shared with sibling frames in this style group
+                (vanilla atlas means letters in the same atlas all share the
+                wood region).
+              </p>
+            )}
           </div>
         )}
 
@@ -293,5 +353,66 @@ export function SlotCard({ slot, state, onChange }: Props) {
         />
       )}
     </>
+  )
+}
+
+interface LiveSlotPreviewProps {
+  slot: SlotDef
+  file: File | undefined
+  framePresetId: string
+  hasImage: boolean
+}
+
+// Backing-store resolution. Tile is up to 735×898 in atlas pixels; we render
+// at native tile resolution for crispness, and CSS scales it to fit the
+// drop zone.
+function previewBackingSize(slot: SlotDef): { w: number; h: number } {
+  if (slot.atlasTile) return { w: slot.atlasTile.w, h: slot.atlasTile.h }
+  return { w: 512, h: 512 }
+}
+
+/**
+ * Live atlas-composited preview rendered into a canvas. Re-runs whenever
+ * the file or frame tint changes. While re-rendering or when no image has
+ * been uploaded yet, shows the empty-state hint over the canvas.
+ *
+ * Calls drawSlotPreviewInto, which routes through composeAtlas ~ the same
+ * function the modlet build uses. So this preview is byte-identical to
+ * what ships in the zip, just shrunk to drop-zone size.
+ */
+function LiveSlotPreview({ slot, file, framePresetId, hasImage }: LiveSlotPreviewProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const { w, h } = previewBackingSize(slot)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    if (!canvas) return
+    let cancelled = false
+    drawSlotPreviewInto(canvas, slot, framePresetId, file).catch(() => {
+      // A failed preview shouldn't break the upload affordance ~ the canvas
+      // just stays blank and the empty-state hint above takes over visually.
+    }).then(() => {
+      if (cancelled) return
+    })
+    return () => { cancelled = true }
+  }, [slot, framePresetId, file])
+
+  return (
+    <div className="relative w-full h-full">
+      <canvas
+        ref={canvasRef}
+        width={w}
+        height={h}
+        className="w-full h-full block"
+      />
+      {!hasImage && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <div className="text-center text-zinc-300 px-4 bg-black/40 rounded py-2">
+            <div className="text-3xl mb-1 leading-none">+</div>
+            <div className="text-xs">drop image or click</div>
+          </div>
+        </div>
+      )}
+    </div>
   )
 }

--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -16,6 +16,32 @@ export interface AtlasTile {
   h: number
 }
 
+/**
+ * Normalized UV bounding box of the front face of a block's LOD0 mesh.
+ * Coordinates are in [0,1] with (0,0) at the top-left of the texture and
+ * (1,1) at the bottom-right ~ matching how UnityPy's read_*_uvs scripts
+ * report them after Y-flipping from OpenGL UV space (0,0 bottom-left) to
+ * PIL/atlas pixel space (0,0 top-left).
+ *
+ * For decor slots whose vanilla mesh samples a sub-region of the texture
+ * (e.g. snack posters that look at only the left half or center quarter),
+ * the composer paints the user's image into exactly this bbox of the
+ * output texture so the mesh sees their full image, undistorted.
+ *
+ * Slots without a meshUvBbox are assumed to sample the full (0,0)-(1,1)
+ * UV range ~ which is what composer's existing fallback behavior assumes.
+ */
+export interface MeshUvBbox {
+  /** Left edge in normalized UV (0..1). */
+  l: number
+  /** Top edge in normalized UV (0..1). */
+  t: number
+  /** Right edge in normalized UV (0..1). */
+  r: number
+  /** Bottom edge in normalized UV (0..1). */
+  b: number
+}
+
 export interface SlotDef {
   /** Unique slot identifier ~ used as the React key and the state Record key. */
   slotId: string
@@ -45,6 +71,23 @@ export interface SlotDef {
    * to (1,1)/(0,0), so the user's image fills the whole canvas. Composer
    * just normalizes the image to a square ~1024×1024.
    */
+  /**
+   * For decor slots whose vanilla mesh samples a sub-region of the texture,
+   * the normalized UV bbox the LOD0 mesh's front face actually reads.
+   * Composer paints the user's image into exactly this bbox of the output
+   * texture so the in-game mesh sees their full image, not a cropped slice.
+   *
+   * Derived empirically via scripts/read_snack_poster_uvs.py. Slots without
+   * this field default to (0,0)-(1,1) ~ image fills full output texture.
+   */
+  meshUvBbox?: MeshUvBbox
+  /**
+   * Optional caveat shown to users in the slot card header. Use for slots
+   * where the vanilla art is misleading ~ e.g. a snack poster tile that
+   * actually contains multiple stacked product designs in one block. Keep
+   * it short; this surfaces as a one-liner above the drop zone.
+   */
+  note?: string
 }
 
 /** Map a shared-atlas materialName to its base atlas image + dimensions. */
@@ -173,23 +216,23 @@ export const SLOTS: SlotDef[] = [
   // material name, each slot gets its own composed texture file (DLL resets
   // UV scale/offset on swap so the user's full image fills each canvas).
   // The atlasTile field is purely for the reference thumb crop.
-  { slotId: 'signSnackPosterJerky',        materialName: 'snackPosterJerky',        label: 'Snack ~ Thick Nick\'s Jerky', vanillaBlocks: ['signSnackPosterJerky'],        kind: 'decor', atlasTile: { x: 0,    y: 0,    w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterGoblinO',      materialName: 'snackPosterGoblinO',      label: "Snack ~ Goblin-O's",          vanillaBlocks: ['signSnackPosterGoblinO'],      kind: 'decor', atlasTile: { x: 410,  y: 0,    w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterOops',         materialName: 'snackPosterOops',         label: 'Snack ~ Oops Country',        vanillaBlocks: ['signSnackPosterOops'],         kind: 'decor', atlasTile: { x: 820,  y: 0,    w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterOopsClassic',  materialName: 'snackPosterOopsClassic',  label: 'Snack ~ Oops Classic',        vanillaBlocks: ['signSnackPosterOopsClassic'],  kind: 'decor', atlasTile: { x: 1230, y: 0,    w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterBretzels',     materialName: 'snackPosterBretzels',     label: 'Snack ~ Bretzels',            vanillaBlocks: ['signSnackPosterBretzels'],     kind: 'decor', atlasTile: { x: 1640, y: 0,    w: 408,  h: 512 } },
-  { slotId: 'signSnackPosterJailBreakers', materialName: 'snackPosterJailBreakers', label: 'Snack ~ Jail Breakers',       vanillaBlocks: ['signSnackPosterJailBreakers'], kind: 'decor', atlasTile: { x: 0,    y: 512,  w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterEyeCandy',     materialName: 'snackPosterEyeCandy',     label: 'Snack ~ Eye Candy',           vanillaBlocks: ['signSnackPosterEyeCandy'],     kind: 'decor', atlasTile: { x: 410,  y: 512,  w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterSkullCrusher', materialName: 'snackPosterSkullCrusher', label: 'Snack ~ Skull Crushers',      vanillaBlocks: ['signSnackPosterSkullCrusher'], kind: 'decor', atlasTile: { x: 820,  y: 512,  w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterNachos',       materialName: 'snackPosterNachos',       label: 'Snack ~ Nachios Beef',        vanillaBlocks: ['signSnackPosterNachos'],       kind: 'decor', atlasTile: { x: 1230, y: 512,  w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterNachosRanch',  materialName: 'snackPosterNachosRanch',  label: 'Snack ~ Nachios Ranch',       vanillaBlocks: ['signSnackPosterNachosRanch'],  kind: 'decor', atlasTile: { x: 1640, y: 512,  w: 408,  h: 512 } },
-  { slotId: 'signSnackPosterFortBites',    materialName: 'snackPosterFortBites',    label: 'Snack ~ Fort Bites',          vanillaBlocks: ['signSnackPosterFortBites'],    kind: 'decor', atlasTile: { x: 0,    y: 1024, w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterHealth',       materialName: 'snackPosterHealth',       label: 'Snack ~ Health Bar (wide)',   vanillaBlocks: ['signSnackPosterHealth'],       kind: 'decor', atlasTile: { x: 410,  y: 1024, w: 1638, h: 512 } },
-  { slotId: 'signSnackPosterHackers',      materialName: 'snackPosterHackers',      label: 'Snack ~ Hackers',             vanillaBlocks: ['signSnackPosterHackers'],      kind: 'decor', atlasTile: { x: 0,    y: 1536, w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterPrime',        materialName: 'snackPosterPrime',        label: 'Snack ~ Prime Bars',          vanillaBlocks: ['signSnackPosterPrime'],        kind: 'decor', atlasTile: { x: 410,  y: 1536, w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterAtom',         materialName: 'snackPosterAtom',         label: 'Snack ~ Atom Junkies',        vanillaBlocks: ['signSnackPosterAtom'],         kind: 'decor', atlasTile: { x: 820,  y: 1536, w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterNerd',         materialName: 'snackPosterNerd',         label: 'Snack ~ Nerd Tats',           vanillaBlocks: ['signSnackPosterNerd'],         kind: 'decor', atlasTile: { x: 1230, y: 1536, w: 410,  h: 512 } },
-  { slotId: 'signSnackPosterRamen',        materialName: 'snackPosterRamen',        label: 'Snack ~ Ramen',               vanillaBlocks: ['signSnackPosterRamen'],        kind: 'decor', atlasTile: { x: 1640, y: 1536, w: 408,  h: 512 } },
+  { slotId: 'signSnackPosterJerky',        materialName: 'snackPosterJerky',        label: 'Snack ~ Thick Nick\'s Jerky', vanillaBlocks: ['signSnackPosterJerky'],        kind: 'decor', atlasTile: { x: 0,    y: 0,    w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterGoblinO',      materialName: 'snackPosterGoblinO',      label: "Snack ~ Goblin-O's",          vanillaBlocks: ['signSnackPosterGoblinO'],      kind: 'decor', atlasTile: { x: 410,  y: 0,    w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterOops',         materialName: 'snackPosterOops',         label: 'Snack ~ Oops Country',        vanillaBlocks: ['signSnackPosterOops'],         kind: 'decor', atlasTile: { x: 820,  y: 0,    w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterOopsClassic',  materialName: 'snackPosterOopsClassic',  label: 'Snack ~ Oops Classic',        vanillaBlocks: ['signSnackPosterOopsClassic'],  kind: 'decor', atlasTile: { x: 1230, y: 0,    w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterBretzels',     materialName: 'snackPosterBretzels',     label: 'Snack ~ Bretzels',            vanillaBlocks: ['signSnackPosterBretzels'],     kind: 'decor', atlasTile: { x: 1640, y: 0,    w: 408,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterJailBreakers', materialName: 'snackPosterJailBreakers', label: 'Snack ~ Jail Breakers',       vanillaBlocks: ['signSnackPosterJailBreakers'], kind: 'decor', atlasTile: { x: 0,    y: 512,  w: 410,  h: 512 }, meshUvBbox: { l: 0.3799, t: 0.2783, r: 0.5835, b: 0.5562 } },
+  { slotId: 'signSnackPosterEyeCandy',     materialName: 'snackPosterEyeCandy',     label: 'Snack ~ Eye Candy',           vanillaBlocks: ['signSnackPosterEyeCandy'],     kind: 'decor', atlasTile: { x: 410,  y: 512,  w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterSkullCrusher', materialName: 'snackPosterSkullCrusher', label: 'Snack ~ Skull Crushers',      vanillaBlocks: ['signSnackPosterSkullCrusher'], kind: 'decor', atlasTile: { x: 820,  y: 512,  w: 410,  h: 512 }, meshUvBbox: { l: 0.3799, t: 0.2783, r: 0.5835, b: 0.5562 } },
+  { slotId: 'signSnackPosterNachos',       materialName: 'snackPosterNachos',       label: 'Snack ~ Nachios Beef',        vanillaBlocks: ['signSnackPosterNachos'],       kind: 'decor', atlasTile: { x: 1230, y: 512,  w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterNachosRanch',  materialName: 'snackPosterNachosRanch',  label: 'Snack ~ Nachios Ranch',       vanillaBlocks: ['signSnackPosterNachosRanch'],  kind: 'decor', atlasTile: { x: 1640, y: 512,  w: 408,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 } },
+  { slotId: 'signSnackPosterFortBites',    materialName: 'snackPosterFortBites',    label: 'Snack ~ Fort Bites',          vanillaBlocks: ['signSnackPosterFortBites'],    kind: 'decor', atlasTile: { x: 0,    y: 1024, w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0.5566, r: 0.2808, b: 0.7197 } },
+  { slotId: 'signSnackPosterHealth',       materialName: 'snackPosterHealth',       label: 'Snack ~ Health Bar (wide)',   vanillaBlocks: ['signSnackPosterHealth'],       kind: 'decor', atlasTile: { x: 410,  y: 1024, w: 1638, h: 512 }, meshUvBbox: { l: 0.0015, t: 0.0044, r: 0.9985, b: 0.499 } },
+  { slotId: 'signSnackPosterHackers',      materialName: 'snackPosterHackers',      label: 'Snack ~ Hackers',             vanillaBlocks: ['signSnackPosterHackers'],      kind: 'decor', atlasTile: { x: 0,    y: 1536, w: 410,  h: 512 }, meshUvBbox: { l: 0.3799, t: 0.2783, r: 0.5835, b: 0.5562 } },
+  { slotId: 'signSnackPosterPrime',        materialName: 'snackPosterPrime',        label: 'Snack ~ Prime Bars',          vanillaBlocks: ['signSnackPosterPrime'],        kind: 'decor', atlasTile: { x: 410,  y: 1536, w: 410,  h: 512 }, meshUvBbox: { l: 0.3799, t: 0.2783, r: 0.5835, b: 0.5562 }, note: 'Vanilla art on this block is a multi-panel design - your image replaces the whole tile.' },
+  { slotId: 'signSnackPosterAtom',         materialName: 'snackPosterAtom',         label: 'Snack ~ Atom Junkies',        vanillaBlocks: ['signSnackPosterAtom'],         kind: 'decor', atlasTile: { x: 820,  y: 1536, w: 410,  h: 512 }, meshUvBbox: { l: 0.3799, t: 0.2783, r: 0.5835, b: 0.5562 }, note: 'Vanilla art on this block is a multi-panel design - your image replaces the whole tile.' },
+  { slotId: 'signSnackPosterNerd',         materialName: 'snackPosterNerd',         label: 'Snack ~ Nerd Tats',           vanillaBlocks: ['signSnackPosterNerd'],         kind: 'decor', atlasTile: { x: 1230, y: 1536, w: 410,  h: 512 }, meshUvBbox: { l: 0, t: 0, r: 0.4985, b: 1 }, note: 'Vanilla art on this block is a multi-panel design - your image replaces the whole tile.' },
+  { slotId: 'signSnackPosterRamen',        materialName: 'snackPosterRamen',        label: 'Snack ~ Ramen',               vanillaBlocks: ['signSnackPosterRamen'],        kind: 'decor', atlasTile: { x: 1640, y: 1536, w: 408,  h: 512 }, meshUvBbox: { l: 0.0015, t: 0.0044, r: 0.9985, b: 0.499 }, note: 'Vanilla art on this block is a multi-panel design - your image replaces the whole tile.' },
 
   // Picture frames ~ 23 individual slots (one per pictureFrame_01<letter>
   // block) across 8 shared atlases. Each letter samples its own tile of the

--- a/src/utils/buildModlet.ts
+++ b/src/utils/buildModlet.ts
@@ -13,6 +13,7 @@ import {
   composeAbstract,
   composeAtlas,
   composeIcon,
+  composeUvBboxFitted,
 } from './composer'
 import { PICKUP_BLOCKS, EXTENDED_DECOR_PICKUP_BLOCKS } from './pickupBlocks'
 
@@ -157,9 +158,15 @@ async function composeForSlot(slot: SlotDef, state: SlotState): Promise<Blob> {
     return composePortrait(state.file, state.framePresetId || DEFAULT_FRAME_PRESET_ID)
   }
   if (slot.kind === 'abstract' || slot.kind === 'decor') {
-    // Both kinds normalize to a square 1024x1024 ~ DLL resets UV scale/offset
-    // on swap so the user's full image fills the canvas regardless of the
-    // material's vanilla atlas-half offset.
+    // Slots with meshUvBbox: paint into the bbox region of a 2048×2048
+    // transparent texture so the in-game mesh's sub-region UV samples the
+    // user's full image. Snack posters use this; other decor slots fall
+    // through to the original cover-fit path.
+    if (slot.meshUvBbox) {
+      return composeUvBboxFitted(state.file, slot.meshUvBbox)
+    }
+    // Otherwise: 1024×1024 cover-fit. Runtime DLL resets UV scale/offset so
+    // the full image fills the canvas regardless of vanilla atlas-half offset.
     return composeAbstract(state.file)
   }
   // moviePoster / canvasTile are handled in batch by composeAtlas, not here.

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_FRAME_PRESET_ID,
   ATLAS_SOURCES,
   type AtlasTile,
+  type MeshUvBbox,
 } from '../types/slots'
 
 const PORTRAIT_W = 1024
@@ -85,6 +86,91 @@ export async function composeAbstract(file: File): Promise<Blob> {
   if (!ctx) throw new Error('Canvas 2d context unavailable')
 
   drawCover(ctx, img, 0, 0, ABSTRACT_SIZE, ABSTRACT_SIZE)
+  return canvasToBlob(canvas)
+}
+
+// Output texture size for UV-bbox-fitted decor textures. 2048 matches the
+// original snackPosters_d atlas dimensions ~ keeps the user's image at full
+// resolution within whatever sub-region the mesh actually samples.
+const UV_BBOX_OUTPUT_SIZE = 2048
+
+/**
+ * Compose a decor texture where the in-game mesh samples only a sub-region
+ * of the texture's UV space. Paints the user's image cover-fitted into
+ * exactly that bbox region (plus a small bleed margin) of an otherwise-
+ * transparent UV_BBOX_OUTPUT_SIZE square so the mesh sees their full image
+ * undistorted, with no edge clipping from sub-pixel rounding.
+ *
+ * Why this exists: snack posters (and likely a handful of other decor
+ * blocks) have meshes whose front-face UVs were authored against the
+ * vanilla shared atlas. e.g. a Bretzels block's mesh samples UV (0,0)-(0.5,1)
+ * because in vanilla that was where the Bretzels artwork lived in the
+ * 2048x2048 snackPosters_d atlas. When we swap in a fresh user texture
+ * AND the runtime DLL resets the material's UV scale/offset to identity,
+ * the mesh STILL asks for (0,0)-(0.5,1) of the new texture ~ which means
+ * the user only sees the left half of their image on the wall.
+ *
+ * Fix: pre-distort. Render a 2048x2048 texture where the user's image
+ * occupies the bbox region (plus BLEED_PX of overflow on each side) and
+ * the rest is transparent. Mesh samples its bbox -> sees full image. The
+ * bleed compensates for fractional UV bboxes (e.g. Bretzels is 0.4985, not
+ * exactly 0.5) so no edge content is lost to round-down. Bleed pixels
+ * extend INTO unsampled territory, so they're cosmetically invisible.
+ * Other materials sharing the shader don't sample the transparent regions,
+ * so no visual leak.
+ */
+// Bleed: how many pixels to extend the destination rect OUTSIDE the bbox.
+// Compensates for fractional UV bboxes (e.g. Bretzels 0.4985, not 0.5)
+// rounding down. Bleed pixels land in unsampled territory, invisible.
+const BBOX_BLEED_PX = 4
+
+// Inset: how many pixels of transparent margin to leave INSIDE the bbox
+// before the user's image starts. Compensates for the in-game mesh's edge
+// sampling (mesh samples ~ 5px in from the bbox edge in practice, depending
+// on texture filtering + mipmap selection). Inset pushes user content
+// safely away from that boundary so edge text isn't clipped.
+//
+// Tradeoff: thin transparent border around the image in-game. At 12 px on
+// a 2048 output, that's ~0.6% of texture per side ~ visually it just looks
+// like a bit of vanilla material framing the print. Bump up if you still
+// see edge clipping; bump down if the framing feels too pronounced.
+const BBOX_INSET_PX = 12
+export async function composeUvBboxFitted(file: File, bbox: MeshUvBbox): Promise<Blob> {
+  const img = await loadImage(file)
+  const canvas = document.createElement('canvas')
+  canvas.width = UV_BBOX_OUTPUT_SIZE
+  canvas.height = UV_BBOX_OUTPUT_SIZE
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2d context unavailable')
+
+  // Convert normalized UV bbox to pixel rect on the output texture.
+  const px = Math.round(bbox.l * UV_BBOX_OUTPUT_SIZE)
+  const py = Math.round(bbox.t * UV_BBOX_OUTPUT_SIZE)
+  const pw = Math.round((bbox.r - bbox.l) * UV_BBOX_OUTPUT_SIZE)
+  const ph = Math.round((bbox.b - bbox.t) * UV_BBOX_OUTPUT_SIZE)
+
+  // Step 1: bleed OUT past the bbox edges to absorb fractional-UV rounding.
+  // Clamped to [0, OUTPUT_SIZE] so a bbox already at the texture edge
+  // doesn't try to draw outside the canvas.
+  const bx = Math.max(0, px - BBOX_BLEED_PX)
+  const by = Math.max(0, py - BBOX_BLEED_PX)
+  const br = Math.min(UV_BBOX_OUTPUT_SIZE, px + pw + BBOX_BLEED_PX)
+  const bb = Math.min(UV_BBOX_OUTPUT_SIZE, py + ph + BBOX_BLEED_PX)
+
+  // Step 2: inset BACK IN past the inner edge so the user's image sits
+  // inside the safety margin. The inset fights mesh-edge sampling which
+  // tends to nibble a few pixels off rendered content at the bbox boundary.
+  // The annular gap between bled rect and inset rect stays transparent ~
+  // visible as a thin border in-game.
+  const ix = bx + BBOX_INSET_PX
+  const iy = by + BBOX_INSET_PX
+  const iw = Math.max(0, (br - bx) - BBOX_INSET_PX * 2)
+  const ih = Math.max(0, (bb - by) - BBOX_INSET_PX * 2)
+
+  // Cover-fit into the inset rect. Same drawCover semantics as everywhere
+  // else in this file ~ aspect-correct, center-cropped.
+  drawCover(ctx, img, ix, iy, iw, ih)
+
   return canvasToBlob(canvas)
 }
 

--- a/src/utils/livePreview.ts
+++ b/src/utils/livePreview.ts
@@ -1,0 +1,357 @@
+// Live preview composition for slot drop zones and frame picker swatches.
+// Uses the same composer.ts code path the modlet build uses for the tinted-
+// atlas layer ~ what you see in the wood is byte-identical to what ships
+// in the zip's frame-zone pixels.
+//
+// Two products:
+//   - drawSwatchInto(canvas, slot, framePresetId): renders a frame-tint
+//     swatch. Branches on slot kind:
+//       * portrait slots ~ paints the preset's imagePath PNG (the 256×1024
+//         strip that wraps the 3D wood frame mesh in-game). Same source
+//         the old <img> swatches used; rendered into a canvas for
+//         consistency with the picture-frame path.
+//       * canvasTile picture-frame slots ~ a fixed wood-region crop from
+//         the slot's tinted atlas, so the six swatches read as "tint
+//         families" rather than abstract striped patterns.
+//       * anything else without a usable source ~ leaves the canvas blank.
+//   - drawSlotPreviewInto(canvas, slot, framePresetId, file?): the slot's
+//     canvas tile, optionally with the user's image, surrounded by a
+//     simulated wood-frame border sourced from the same tinted atlas.
+//     IMPORTANT: this is a *visualization* of how the block looks in-game,
+//     not a 1:1 of the modlet's output texture. The modlet outputs only
+//     the canvas tile region; the wood molding visible in-game comes from
+//     the surrounding 3D mesh sampling other parts of the atlas. We
+//     simulate that mesh contribution here so users get a "what it'll
+//     look like on the wall" preview rather than a raw canvas crop.
+//
+// Both share a memo on (materialName, tint) so all six swatches plus the
+// drop zone preview only force the atlas through composeAtlas once per
+// tint variant. The cache lives for the lifetime of the page.
+
+import {
+  ATLAS_SOURCES,
+  FRAME_PRESETS,
+  DEFAULT_FRAME_PRESET_ID,
+  type SlotDef,
+  type FramePreset,
+} from '../types/slots'
+import { composeAtlas } from './composer'
+
+// Pixel rect inside the wood-frame zone that's reliably wood-grain across
+// every pictureFramed* atlas. Sampled from the middle of the top 55% so
+// edge artifacts and mitre corners aren't in shot.
+const SWATCH_SAMPLE = { x: 900, y: 400, w: 240, h: 240 }
+
+// Pixel rect for the simulated frame border. Same sampling philosophy as
+// SWATCH_SAMPLE but a longer, slightly taller strip ~ we'll project this
+// onto the four border sides at preview resolution.
+const BORDER_SAMPLE = { x: 200, y: 350, w: 1400, h: 320 }
+
+// Frame border thickness as a fraction of the preview's shorter dimension.
+// Real-life picture frames sit around 6–10% depending on style; 9% reads
+// as "ornate-ish" without crowding the canvas.
+const BORDER_THICKNESS_PCT = 0.09
+
+// Cache: tinted full atlases (NO user image) keyed by `${materialName}|${tint}`.
+// Stored as Promise<HTMLCanvasElement> so concurrent first-callers all share
+// the in-flight fetch ~ a fresh slot card with 6 swatches only triggers one
+// atlas load, not six. Promise resolves to a canvas we can drawImage from.
+const _tintedAtlasCache = new Map<string, Promise<HTMLCanvasElement>>()
+
+// Cache: portrait frame-strip PNGs (preset.imagePath -> HTMLImageElement)
+// loaded once and reused for every portrait swatch. Mirrors the pattern in
+// composer.ts loadFrameTexture, kept separate to avoid coupling.
+const _frameStripCache = new Map<string, Promise<HTMLImageElement>>()
+
+/** Resolve a preset id to its preset record, falling back to default. */
+function resolvePreset(framePresetId: string | undefined): FramePreset {
+  return (
+    FRAME_PRESETS.find(p => p.id === framePresetId) ??
+    FRAME_PRESETS.find(p => p.id === DEFAULT_FRAME_PRESET_ID) ??
+    FRAME_PRESETS[0]
+  )
+}
+
+/** Resolve a preset id to its tint hex (or undefined for "no tint"). */
+function resolveTint(framePresetId: string | undefined): string | undefined {
+  return resolvePreset(framePresetId).tint
+}
+
+/**
+ * Run composeAtlas with no entries to get the vanilla atlas + tint applied,
+ * with the result captured as a canvas. Memoized per (materialName, tint).
+ *
+ * We use composeAtlas directly so the tint blend mode + zone height stay in
+ * lockstep with whatever the modlet build does. Empty entries means no
+ * user image is painted; this is intentional ~ the slot-with-image path
+ * composites the image client-side at preview resolution rather than
+ * paying for a full 2048×2048 atlas re-bake on every tint flip.
+ */
+async function getTintedAtlas(
+  materialName: string,
+  tint: string | undefined,
+): Promise<HTMLCanvasElement> {
+  const key = `${materialName}|${tint ?? ''}`
+  let inflight = _tintedAtlasCache.get(key)
+  if (inflight) return inflight
+
+  inflight = (async () => {
+    const blob = await composeAtlas(materialName, [], tint)
+    const url = URL.createObjectURL(blob)
+    try {
+      const img = await loadImageFromUrl(url)
+      const canvas = document.createElement('canvas')
+      canvas.width = img.width
+      canvas.height = img.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) throw new Error('Canvas 2d context unavailable')
+      ctx.drawImage(img, 0, 0)
+      return canvas
+    } finally {
+      URL.revokeObjectURL(url)
+    }
+  })()
+
+  _tintedAtlasCache.set(key, inflight)
+  return inflight
+}
+
+async function getFrameStrip(imagePath: string): Promise<HTMLImageElement> {
+  let inflight = _frameStripCache.get(imagePath)
+  if (inflight) return inflight
+  inflight = loadImageFromUrl(imagePath)
+  _frameStripCache.set(imagePath, inflight)
+  return inflight
+}
+
+function loadImageFromUrl(url: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.onload = () => resolve(img)
+    img.onerror = () => reject(new Error(`Failed to load image: ${url}`))
+    img.src = url
+  })
+}
+
+/**
+ * Render the swatch for a frame picker entry. Branches on slot kind so
+ * portrait slots get their PNG strip and picture-frame slots get their
+ * tinted atlas wood region.
+ */
+export async function drawSwatchInto(
+  canvas: HTMLCanvasElement,
+  slot: SlotDef,
+  framePresetId: string,
+): Promise<HTMLCanvasElement> {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return canvas
+
+  // Portrait swatches: render the preset's vertical strip image. Strip
+  // dimensions are 256×1024; the swatch is wider-than-tall (~3:1) so we
+  // crop a horizontal slice from the strip's vertical middle.
+  if (slot.kind === 'portrait') {
+    const preset = resolvePreset(framePresetId)
+    try {
+      const img = await getFrameStrip(preset.imagePath)
+      ctx.clearRect(0, 0, canvas.width, canvas.height)
+      // Crop a centered slice that's the same aspect as the canvas so the
+      // wood pattern reads as a flat fragment, not a stretched strip.
+      const dstRatio = canvas.width / canvas.height
+      let sw = img.width
+      let sh = sw / dstRatio
+      if (sh > img.height) {
+        sh = img.height
+        sw = sh * dstRatio
+      }
+      const sx = (img.width - sw) / 2
+      const sy = (img.height - sh) / 2
+      ctx.drawImage(img, sx, sy, sw, sh, 0, 0, canvas.width, canvas.height)
+    } catch {
+      // Failed strip load ~ leave blank rather than crash.
+    }
+    return canvas
+  }
+
+  // Picture-frame swatches: tinted atlas wood region.
+  const source = ATLAS_SOURCES[slot.materialName]
+  if (!source) return canvas
+
+  const tint = resolveTint(framePresetId)
+  const atlas = await getTintedAtlas(slot.materialName, tint)
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  ctx.drawImage(
+    atlas,
+    SWATCH_SAMPLE.x, SWATCH_SAMPLE.y, SWATCH_SAMPLE.w, SWATCH_SAMPLE.h,
+    0, 0, canvas.width, canvas.height,
+  )
+  return canvas
+}
+
+/**
+ * Render the live drop-zone preview for a slot: the canvas tile (with the
+ * user's image, if uploaded) wrapped in a simulated wood-frame border
+ * sourced from the tinted atlas. The result is a "what it'll look like in
+ * the world" visualization, not a raw modlet-output crop.
+ */
+export async function drawSlotPreviewInto(
+  canvas: HTMLCanvasElement,
+  slot: SlotDef,
+  framePresetId: string | undefined,
+  file: File | undefined,
+): Promise<HTMLCanvasElement> {
+  const ctx = canvas.getContext('2d')
+  if (!ctx) return canvas
+
+  const W = canvas.width
+  const H = canvas.height
+  const source = ATLAS_SOURCES[slot.materialName]
+
+  // Slots without a shared atlas (portraits, standalone decor) ~ honest
+  // fallback to current behavior, just draw the raw image.
+  if (!source || !slot.atlasTile) {
+    ctx.clearRect(0, 0, W, H)
+    if (file) {
+      const img = await loadImageFromFile(file)
+      drawCover(ctx, img, 0, 0, W, H)
+    }
+    return canvas
+  }
+
+  ctx.clearRect(0, 0, W, H)
+
+  // Inner canvas zone (image-bearing area).
+  const t = Math.round(Math.min(W, H) * BORDER_THICKNESS_PCT)
+  const ix = t, iy = t, iw = W - t * 2, ih = H - t * 2
+
+  // 1. Inner canvas region: vanilla canvas-zone color + user image.
+  // Vanilla canvas zones in the atlas are typically a near-white linen,
+  // so a light off-white base is honest if the user hasn't uploaded yet.
+  ctx.fillStyle = '#d4d2cc'
+  ctx.fillRect(ix, iy, iw, ih)
+  if (file) {
+    const img = await loadImageFromFile(file)
+    drawCover(ctx, img, ix, iy, iw, ih)
+  }
+
+  // 2. Wood-frame borders. Pull a horizontal strip from the tinted atlas
+  // and project it onto each of the four sides. Mitre clips at the corners.
+  const tint = resolveTint(framePresetId)
+  const atlas = await getTintedAtlas(slot.materialName, tint)
+  drawFrameBorder(ctx, atlas, W, H, t)
+
+  // 3. Inner shadow on the canvas opening ~ sells "the canvas sits inside
+  // the frame" by darkening the inner edge.
+  ctx.save()
+  ctx.strokeStyle = 'rgba(0,0,0,0.4)'
+  ctx.lineWidth = 1.5
+  ctx.strokeRect(ix + 0.75, iy + 0.75, iw - 1.5, ih - 1.5)
+  ctx.restore()
+
+  return canvas
+}
+
+/**
+ * Paint the four wood-frame strips around the canvas zone, with 45° mitres
+ * at the corners. Each strip is the BORDER_SAMPLE rect of the atlas,
+ * scaled to the strip's size; vertical strips are rotated so the grain
+ * runs along the strip's long axis.
+ */
+function drawFrameBorder(
+  ctx: CanvasRenderingContext2D,
+  atlas: HTMLCanvasElement,
+  W: number, H: number, t: number,
+) {
+  const sx = BORDER_SAMPLE.x, sy = BORDER_SAMPLE.y
+  const sw = BORDER_SAMPLE.w, sh = BORDER_SAMPLE.h
+
+  // Top strip
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(0, 0)
+  ctx.lineTo(W, 0)
+  ctx.lineTo(W - t, t)
+  ctx.lineTo(t, t)
+  ctx.closePath()
+  ctx.clip()
+  ctx.drawImage(atlas, sx, sy, sw, sh, 0, 0, W, t)
+  ctx.restore()
+
+  // Bottom strip
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(t, H - t)
+  ctx.lineTo(W - t, H - t)
+  ctx.lineTo(W, H)
+  ctx.lineTo(0, H)
+  ctx.closePath()
+  ctx.clip()
+  ctx.drawImage(atlas, sx, sy, sw, sh, 0, H - t, W, t)
+  ctx.restore()
+
+  // Left strip ~ rotate 90° so grain runs vertically.
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(0, 0)
+  ctx.lineTo(t, t)
+  ctx.lineTo(t, H - t)
+  ctx.lineTo(0, H)
+  ctx.closePath()
+  ctx.clip()
+  ctx.translate(0, H)
+  ctx.rotate(-Math.PI / 2)
+  ctx.drawImage(atlas, sx, sy, sw, sh, 0, 0, H, t)
+  ctx.restore()
+
+  // Right strip
+  ctx.save()
+  ctx.beginPath()
+  ctx.moveTo(W - t, t)
+  ctx.lineTo(W, 0)
+  ctx.lineTo(W, H)
+  ctx.lineTo(W - t, H - t)
+  ctx.closePath()
+  ctx.clip()
+  ctx.translate(W, 0)
+  ctx.rotate(Math.PI / 2)
+  ctx.drawImage(atlas, sx, sy, sw, sh, 0, 0, H, t)
+  ctx.restore()
+
+  // Mitre seams ~ thin diagonals from outer to inner corner so the joins
+  // read as actual cuts rather than blended texture continuations.
+  ctx.save()
+  ctx.strokeStyle = 'rgba(0,0,0,0.35)'
+  ctx.lineWidth = 1
+  ctx.beginPath()
+  ctx.moveTo(0, 0);     ctx.lineTo(t, t)
+  ctx.moveTo(W, 0);     ctx.lineTo(W - t, t)
+  ctx.moveTo(0, H);     ctx.lineTo(t, H - t)
+  ctx.moveTo(W, H);     ctx.lineTo(W - t, H - t)
+  ctx.stroke()
+  ctx.restore()
+}
+
+function loadImageFromFile(file: File): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    const url = URL.createObjectURL(file)
+    img.onload = () => { URL.revokeObjectURL(url); resolve(img) }
+    img.onerror = () => { URL.revokeObjectURL(url); reject(new Error('Failed to load image')) }
+    img.src = url
+  })
+}
+
+// Mirrors composer.ts drawCover ~ duplicated to avoid exporting an internal
+// helper, kept tiny.
+function drawCover(
+  ctx: CanvasRenderingContext2D,
+  img: HTMLImageElement,
+  dx: number, dy: number, dw: number, dh: number,
+) {
+  const srcRatio = img.width / img.height
+  const dstRatio = dw / dh
+  let sx = 0, sy = 0, sw = img.width, sh = img.height
+  if (srcRatio > dstRatio) { sw = img.height * dstRatio; sx = (img.width - sw) / 2 }
+  else if (srcRatio < dstRatio) { sh = img.width / dstRatio; sy = (img.height - sh) / 2 }
+  ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh)
+}


### PR DESCRIPTION
## what's broken

Three things, fixed together because they overlap in SlotCard:

### 1. snack posters cropped wrong in-game (the big one)

Vanilla snack-poster meshes sample sub-regions of their texture, not the whole thing. The 17 prefabs split into three classes:

- **tall-left** (UV (0,0)-(0.5,1)): Bretzels, EyeCandy, GoblinO, Jerky, Nachos, NachosRanch, Nerd, Oops, OopsClassic
- **centered-medium** (UV (0.38,0.44)-(0.58,0.72)): Atom, Hackers, JailBreakers, Prime, SkullCrusher
- **wide-bottom** (UV (0,0.5)-(1,1)): Health, Ramen
- (FortBites is its own outlier)

Previously \composeAbstract\ output a 1024×1024 cover-fit image; the in-game block only showed whatever sub-region the mesh sampled, cropping user content.

Ran \scripts/read_snack_poster_uvs.py\ to derive the real bboxes per prefab, encoded as \MeshUvBbox\ in \slots.ts\ (17 slots), and added \composeUvBboxFitted\ that paints the user image into exactly that bbox region of a 2048×2048 transparent texture.

Two safety margins:
- **bleed** (4px outside the bbox) absorbs sub-pixel rounding from fractional UVs like 0.4985
- **inset** (12px inside the bbox) keeps content away from the mesh-edge sampling that nibbles the visible boundary

Cropper aspect, drop-zone aspect, and dimensions caption all now use the visible-region aspect via \getVisibleDims\ rather than \tlasTile\, so what users see in the picker matches what ships in-game.

### 2. frame picker swatches read as abstract stripes

The swatches were 12px-tall horizontal slices of 256×1024 vertical wood-strip PNGs ~ which is structurally unreadable, the slice is just noise.

Now branches by slot kind:
- **picture-frame slots** show the slot's tinted vanilla atlas wood region (sampled from the actual atlas pixels the modlet ships)
- **portrait slots** show the preset PNG cropped to a swatch-friendly aspect

Selected state uses outline + border-color swap (not border-width) so clicking doesn't jiggle the grid.

### 3. picture-frame drop zones now show a "wall preview"

Previously the drop zone was just an \<img object-cover>\ of the user's upload. Now it renders a simulation: image inside a wood-grain frame border with mitres, sourced from the same tinted atlas pixels the modlet ships. Updates live when the user switches tints with an image already loaded.

The wood + tint are real (sampled from the actual modlet output pixels). The four-strips-with-mitres geometry is a sim ~ the in-game renderer uses 3D mesh UVs to do the equivalent thing. Close to in-game appearance, more honest than showing just the canvas tile.

### bonus: multi-panel notes

Added optional \
ote\ field on \SlotDef\ and surfaced warnings on Prime Bars / Atom Junkies / Nerd Tats / Ramen ~ tiles whose vanilla art contains multiple stacked product designs. Users were surprised when one image replaced "all" of them.

## files

- \src/types/slots.ts\ ~ \MeshUvBbox\ interface, \meshUvBbox\ + \
ote\ fields on \SlotDef\, 17 snack-poster bboxes, 4 notes
- \src/utils/composer.ts\ ~ \composeUvBboxFitted\ with bleed + inset
- \src/utils/buildModlet.ts\ ~ routes meshUvBbox slots through new composer
- \src/utils/livePreview.ts\ ~ new, drives swatch + frame previews, shared atlas cache
- \src/components/FramePresetPicker.tsx\ ~ canvas swatches, slot-aware
- \src/components/SlotCard.tsx\ ~ \getVisibleDims\ helper, live preview integration, note display

## verification

- type-check clean (\
px tsc --noEmit\)
- 43/43 tests pass (\
px vitest run\)
- in-game tested on Bretzels (tall-left class) and Skull Crushers (centered-medium class) ~ user content displays correctly within the visible mesh region

## known follow-ups (parked)

- **inset tuning** ~ 12px is a starting guess; may need bump to 16-20 if some slots still nibble edges. Skull Crushers test showed slight edge nibbling; bumping to 12px helped but a sliding scale per bbox class would be more correct than a flat px value.
- **web preview doesn't apply the inset** ~ web preview will look slightly fuller than in-game result. Cosmetic, not functional.
- **other decor categories haven't been audited** ~ movie posters, blueprints, target posters, snack-helper-gallery may have the same UV bbox issue. If users report similar "image cut off in-game" symptoms, that's where to look.
- **eslint config is broken** (pre-existing, unrelated) ~ \
px eslint .\ fails because eslint v9 wants \slint.config.js\ instead of legacy \.eslintrc\. Worth a separate small PR.