### PR TITLE
v1.0.3: orientation flip toggle (Frame D/E/F now horizontal by default)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kitsuneprints",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.0.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/SlotCard.tsx
+++ b/src/components/SlotCard.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
-import type { SlotDef, SlotState } from '../types/slots'
-import { ATLAS_SOURCES, DEFAULT_FRAME_PRESET_ID } from '../types/slots'
+import type { SlotDef, SlotState, SlotOrientation } from '../types/slots'
+import {
+  ATLAS_SOURCES,
+  DEFAULT_FRAME_PRESET_ID,
+  getEffectiveOrientation,
+  getSlotDefaultOrientation,
+  slotSupportsOrientationFlip,
+} from '../types/slots'
 import { CropDialog } from './CropDialog'
 import { FramePresetPicker } from './FramePresetPicker'
 import { drawSlotPreviewInto } from '../utils/livePreview'
@@ -47,6 +53,24 @@ function getVisibleDims(slot: SlotDef): { w: number; h: number } | null {
   return null // abstract / standalone decor: square fallback
 }
 
+/**
+ * Visible dims for the slot at the user's CHOSEN orientation. For slots
+ * that support flip, this swaps w/h when the user's effective orientation
+ * differs from the atlasTile's native aspect. Used to drive the cropper
+ * frame, drop-zone aspect, and live-preview backing-store dimensions ~
+ * everything that visualizes the user's image at their picked orientation.
+ */
+function getOrientedDims(slot: SlotDef, state: SlotState): { w: number; h: number } | null {
+  const dims = getVisibleDims(slot)
+  if (!dims) return null
+  if (!slotSupportsOrientationFlip(slot)) return dims
+  const orient = getEffectiveOrientation(slot, state)
+  const dimsArePortrait = dims.h > dims.w
+  const userPortrait = orient === 'portrait'
+  if (dimsArePortrait === userPortrait) return dims
+  return { w: dims.h, h: dims.w }
+}
+
 function pickThumbClass(slot: SlotDef): string {
   if (slot.kind === 'portrait' || slot.kind === 'moviePoster') return 'w-9 h-12'
   if (slot.kind === 'decor') return 'w-10 h-12 object-contain'
@@ -69,11 +93,12 @@ function pickThumbClass(slot: SlotDef): string {
  * Mirrors what the cropper enforces below so the drop zone shape and
  * the crop frame shape stay in sync per slot.
  */
-function getSlotAspectRatio(slot: SlotDef): string {
-  // Drop zone uses the actually-visible aspect (meshUvBbox if present,
-  // else atlasTile, else portrait/square defaults).
+function getSlotAspectRatio(slot: SlotDef, state: SlotState): string {
+  // Drop zone uses the actually-visible aspect, swapped when the user has
+  // toggled orientation on a flippable slot. Portrait slots are fixed 3:4
+  // ~ no flip available there.
   if (slot.kind === 'portrait') return '3 / 4'
-  const dims = getVisibleDims(slot)
+  const dims = getOrientedDims(slot, state)
   if (dims) return `${dims.w} / ${dims.h}`
   return '1 / 1'
 }
@@ -156,19 +181,17 @@ export function SlotCard({ slot, state, onChange }: Props) {
   const [cardRef, isVisible] = useInViewport('300px')
 
   // Aspect for the crop frame:
-  //   - portraits: 3:4 canvas zone
-  //   - any slot with atlasTile (moviePoster, canvasTile, AND decor with
-  //     a shared atlas like snack posters): derived from the tile size.
-  //     Snack posters are decor + atlasTile, mostly 410×512 (4:5) with
-  //     Health Bar an outlier at 1638×512 (~3:1 wide).
-  //   - everything else (abstracts, standalone decor): square. The DLL
-  //     resets UV scale to fill the canvas so square-cropped works.
-  // Cropper aspect: same source as the drop-zone shape, so cropping
-  // matches the shape of the in-game visible region. snack posters get
-  // their meshUvBbox aspect; other slots fall back to atlasTile/portrait.
+  //   - portraits: 3:4 canvas zone (no flip available here)
+  //   - any slot with atlasTile (moviePoster, canvasTile, decor with a
+  //     shared atlas): derived from the tile size, swapped when the
+  //     user's effective orientation differs from the atlasTile's
+  //     native aspect (only happens on flippable slots).
+  //   - everything else (abstracts, standalone decor): square.
+  // Crop aspect tracks the drop-zone aspect 1:1 so the cropping frame
+  // shape matches what the user just dropped onto.
   const aspect = (() => {
     if (slot.kind === 'portrait') return 3 / 4
-    const dims = getVisibleDims(slot)
+    const dims = getOrientedDims(slot, state)
     if (dims) return dims.w / dims.h
     return 1
   })()
@@ -215,7 +238,18 @@ export function SlotCard({ slot, state, onChange }: Props) {
 
   function clearImage(e: React.MouseEvent) {
     e.stopPropagation()
-    onChange(slot.kind === 'portrait' ? { framePresetId: state.framePresetId } : {})
+    // Preserve the user's framePresetId + orientation across a clear so a
+    // re-upload remembers the picker state they had set up.
+    const preserved: SlotState = {}
+    if (state.framePresetId) preserved.framePresetId = state.framePresetId
+    if (state.orientation) preserved.orientation = state.orientation
+    onChange(preserved)
+  }
+
+  function setOrientation(next: SlotOrientation) {
+    // Persist explicit choice even when it matches the slot's default ~
+    // signals "user picked this, don't auto-flip if defaults change."
+    onChange({ ...state, orientation: next })
   }
 
   return (
@@ -253,18 +287,26 @@ export function SlotCard({ slot, state, onChange }: Props) {
           />
         </div>
 
+        {slotSupportsOrientationFlip(slot) && (
+          <OrientationToggle
+            slot={slot}
+            state={state}
+            onChange={setOrientation}
+          />
+        )}
+
         <div
           onDragOver={(e) => e.preventDefault()}
           onDrop={handleDrop}
           onClick={() => fileRef.current?.click()}
           className="bg-zinc-950 border-2 border-dashed border-zinc-700 rounded cursor-pointer flex items-center justify-center overflow-hidden hover:border-zinc-500 transition-colors"
-          style={{ aspectRatio: getSlotAspectRatio(slot) }}
+          style={{ aspectRatio: getSlotAspectRatio(slot, state) }}
         >
           {slotHasLiveFramePreview(slot) ? (
             isVisible ? (
               <LiveSlotPreview
                 slot={slot}
-                file={state.file}
+                state={state}
                 framePresetId={state.framePresetId || DEFAULT_FRAME_PRESET_ID}
                 hasImage={Boolean(state.preview)}
               />
@@ -381,15 +423,21 @@ export function SlotCard({ slot, state, onChange }: Props) {
 
 interface LiveSlotPreviewProps {
   slot: SlotDef
-  file: File | undefined
+  state: SlotState
   framePresetId: string
   hasImage: boolean
 }
 
 // Backing-store resolution. Tile is up to 735×898 in atlas pixels; we render
 // at native tile resolution for crispness, and CSS scales it to fit the
-// drop zone.
-function previewBackingSize(slot: SlotDef): { w: number; h: number } {
+// drop zone. Backing dimensions follow the user's effective orientation so
+// the wood-frame border draws at the same aspect the drop zone displays.
+function previewBackingSize(slot: SlotDef, state: SlotState): { w: number; h: number } {
+  const dims = getOrientedDims(slot, state)
+  if (dims) {
+    if (slot.atlasTile) return dims  // already pixel-sized from atlasTile
+    return { w: 512, h: 512 }
+  }
   if (slot.atlasTile) return { w: slot.atlasTile.w, h: slot.atlasTile.h }
   return { w: 512, h: 512 }
 }
@@ -410,9 +458,11 @@ function previewBackingSize(slot: SlotDef): { w: number; h: number } {
  * in-memory cache and finish quickly enough that the indicator barely
  * flashes ~ that's the desired UX.
  */
-function LiveSlotPreview({ slot, file, framePresetId, hasImage }: LiveSlotPreviewProps) {
+function LiveSlotPreview({ slot, state, framePresetId, hasImage }: LiveSlotPreviewProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
-  const { w, h } = previewBackingSize(slot)
+  const { w, h } = previewBackingSize(slot, state)
+  const file = state.file
+  const orientation = getEffectiveOrientation(slot, state)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
@@ -420,7 +470,12 @@ function LiveSlotPreview({ slot, file, framePresetId, hasImage }: LiveSlotPrevie
     if (!canvas) return
     let cancelled = false
     setLoading(true)
-    drawSlotPreviewInto(canvas, slot, framePresetId, file).catch(() => {
+    // Pass the chosen orientation so drawSlotPreviewInto knows how to
+    // shape the wood-border + image fit. The user's file is already
+    // cropped to the chosen aspect by CropDialog, so no rotation is
+    // applied IN the preview ~ the modlet build path applies rotation
+    // separately when painting into the (still portrait) atlasTile.
+    drawSlotPreviewInto(canvas, slot, framePresetId, file, orientation).catch(() => {
       // A failed preview shouldn't break the upload affordance ~ the canvas
       // just stays blank and the empty-state hint above takes over visually.
     }).finally(() => {
@@ -428,7 +483,7 @@ function LiveSlotPreview({ slot, file, framePresetId, hasImage }: LiveSlotPrevie
       setLoading(false)
     })
     return () => { cancelled = true }
-  }, [slot, framePresetId, file])
+  }, [slot, framePresetId, file, orientation])
 
   return (
     <div className="relative w-full h-full">
@@ -468,6 +523,62 @@ function SwatchSkeleton({ label }: { label: string }) {
       <div className="text-center text-zinc-500 px-4 flex items-center gap-2">
         <span className="inline-block w-3 h-3 rounded-full border-2 border-zinc-700 border-t-zinc-400 animate-spin" />
         <span className="text-xs">{label}</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Two-state Vertical/Horizontal toggle for slots that support orientation
+ * flip. Default highlight follows the slot's vanillaContentRotation
+ * (rotated-landscape vanilla → defaults to Horizontal; everything else →
+ * defaults to Vertical or whichever matches the atlasTile aspect). User's
+ * explicit choice persists in state.orientation and overrides the default.
+ */
+interface OrientationToggleProps {
+  slot: SlotDef
+  state: SlotState
+  onChange: (next: SlotOrientation) => void
+}
+
+function OrientationToggle({ slot, state, onChange }: OrientationToggleProps) {
+  const current = getEffectiveOrientation(slot, state)
+  const def = getSlotDefaultOrientation(slot)
+  return (
+    <div className="mb-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-zinc-500">Orientation</span>
+        <div className="inline-flex rounded border border-zinc-700 overflow-hidden text-xs">
+          <button
+            type="button"
+            onClick={() => onChange('portrait')}
+            className={`px-2.5 py-1 transition-colors ${
+              current === 'portrait'
+                ? 'bg-amber-600/30 text-amber-200'
+                : 'bg-zinc-900 text-zinc-400 hover:bg-zinc-800'
+            }`}
+            title={def === 'portrait' ? 'Vertical (matches vanilla)' : 'Vertical'}
+          >
+            ▯ Vertical
+          </button>
+          <button
+            type="button"
+            onClick={() => onChange('landscape')}
+            className={`px-2.5 py-1 transition-colors border-l border-zinc-700 ${
+              current === 'landscape'
+                ? 'bg-amber-600/30 text-amber-200'
+                : 'bg-zinc-900 text-zinc-400 hover:bg-zinc-800'
+            }`}
+            title={def === 'landscape' ? 'Horizontal (matches vanilla)' : 'Horizontal'}
+          >
+            ▭ Horizontal
+          </button>
+        </div>
+        {state.orientation && state.orientation !== def && (
+          <span className="text-[10px] text-zinc-600 italic">
+            (vanilla is {def})
+          </span>
+        )}
       </div>
     </div>
   )

--- a/src/types/slots.test.ts
+++ b/src/types/slots.test.ts
@@ -1,5 +1,15 @@
 import { describe, it, expect } from 'vitest'
-import { isDefaultPackMeta, DEFAULT_PACK_META } from './slots'
+import {
+  isDefaultPackMeta,
+  DEFAULT_PACK_META,
+  SLOTS,
+  getSlotDefaultOrientation,
+  getEffectiveOrientation,
+  getCompositeRotation,
+  slotSupportsOrientationFlip,
+  type SlotDef,
+  type SlotState,
+} from './slots'
 
 describe('isDefaultPackMeta', () => {
   it('returns true for the unmodified factory default', () => {
@@ -26,5 +36,154 @@ describe('isDefaultPackMeta', () => {
       version: '99.0.0',
       enablePickup: false,
     })).toBe(true)
+  })
+})
+
+const slotById = (id: string): SlotDef => {
+  const s = SLOTS.find(s => s.slotId === id)
+  if (!s) throw new Error(`unknown test slot: ${id}`)
+  return s
+}
+
+describe('orientation helpers', () => {
+  describe('getSlotDefaultOrientation', () => {
+    it('returns portrait for an upright picture frame (atlasTile portrait, no rotation)', () => {
+      // pictureFrame_01a is upright ~ atlasTile is portrait, no vanillaContentRotation.
+      expect(getSlotDefaultOrientation(slotById('pictureFrame_01a'))).toBe('portrait')
+    })
+
+    it('returns landscape for a rotated picture frame (atlasTile portrait, CCW vanilla)', () => {
+      // pictureFrame_01e was rotated CCW to fit a portrait frame; vanilla art
+      // is landscape, so user default is landscape.
+      expect(getSlotDefaultOrientation(slotById('pictureFrame_01e'))).toBe('landscape')
+    })
+
+    it('returns landscape for the CW outlier (pictureFrame_01d, bear)', () => {
+      // 01d's vanilla was rotated CW (the lone outlier among rotated frames).
+      // Default is still landscape ~ direction doesn't change which orientation
+      // the user starts from, only the eventual rotation when compositing.
+      expect(getSlotDefaultOrientation(slotById('pictureFrame_01d'))).toBe('landscape')
+    })
+
+    it('returns landscape for picture canvases (atlasTile already landscape)', () => {
+      // Picture canvases have landscape atlasTiles ~ no flip needed in vanilla.
+      expect(getSlotDefaultOrientation(slotById('pictureCanvas_01a'))).toBe('landscape')
+    })
+
+    it('returns portrait for movie posters (atlasTile portrait, no rotation)', () => {
+      expect(getSlotDefaultOrientation(slotById('signPosterMovieMammasJustice'))).toBe('portrait')
+    })
+  })
+
+  describe('getEffectiveOrientation', () => {
+    it('returns the slot default when the user has not made an explicit choice', () => {
+      const s = slotById('pictureFrame_01e')
+      const state: SlotState = {}
+      expect(getEffectiveOrientation(s, state)).toBe('landscape')
+    })
+
+    it('honors the user choice on flippable slots even when it matches the default', () => {
+      const s = slotById('pictureFrame_01e')
+      const state: SlotState = { orientation: 'landscape' }
+      expect(getEffectiveOrientation(s, state)).toBe('landscape')
+    })
+
+    it('honors the user choice when it overrides the default', () => {
+      const s = slotById('pictureFrame_01e') // default landscape
+      const state: SlotState = { orientation: 'portrait' }
+      expect(getEffectiveOrientation(s, state)).toBe('portrait')
+    })
+
+    it('ignores user choice on non-flippable kinds (portrait slots)', () => {
+      const s = slotById('painting_ben') // kind: portrait, no flip
+      const state: SlotState = { orientation: 'landscape' }
+      expect(getEffectiveOrientation(s, state)).toBe('portrait')
+    })
+  })
+
+  describe('getCompositeRotation', () => {
+    it('returns undefined when user orientation matches the atlasTile aspect', () => {
+      // Upright picture frame ~ tile is portrait, default is portrait, no rotation.
+      const s = slotById('pictureFrame_01a')
+      expect(getCompositeRotation(s, {})).toBeUndefined()
+    })
+
+    it('returns the slot vanillaContentRotation when user picks the opposite-of-tile orientation (CCW case)', () => {
+      // pictureFrame_01e: tile portrait, default landscape. User on default
+      // means we paint a landscape upload into a portrait tile ~ rotate CCW
+      // to match the vanilla style.
+      const s = slotById('pictureFrame_01e')
+      expect(getCompositeRotation(s, {})).toBe('ccw')
+    })
+
+    it('returns the slot vanillaContentRotation for the CW outlier (pictureFrame_01d)', () => {
+      const s = slotById('pictureFrame_01d')
+      expect(getCompositeRotation(s, {})).toBe('cw')
+    })
+
+    it('returns undefined when user toggles back to portrait on a rotated-default slot', () => {
+      const s = slotById('pictureFrame_01e') // tile portrait, default landscape
+      const state: SlotState = { orientation: 'portrait' } // user wants upright
+      expect(getCompositeRotation(s, state)).toBeUndefined()
+    })
+
+    it("falls back to CCW when an upright slot is toggled to landscape (no recorded vanilla rotation)", () => {
+      const s = slotById('pictureFrame_01a') // upright; vanillaContentRotation is undefined
+      const state: SlotState = { orientation: 'landscape' }
+      expect(getCompositeRotation(s, state)).toBe('ccw')
+    })
+  })
+
+  describe('slotSupportsOrientationFlip', () => {
+    it('is true for canvasTile slots (picture frames + canvases)', () => {
+      expect(slotSupportsOrientationFlip(slotById('pictureFrame_01a'))).toBe(true)
+      expect(slotSupportsOrientationFlip(slotById('pictureCanvas_01a'))).toBe(true)
+    })
+
+    it('is true for moviePoster slots', () => {
+      expect(slotSupportsOrientationFlip(slotById('signPosterMovieMammasJustice'))).toBe(true)
+    })
+
+    it('is false for portrait slots (composer rotation would clobber the wood-zone UV split)', () => {
+      expect(slotSupportsOrientationFlip(slotById('painting_ben'))).toBe(false)
+    })
+
+    it('is false for abstract slots', () => {
+      expect(slotSupportsOrientationFlip(slotById('paintingsAbstract01'))).toBe(false)
+    })
+
+    it('is false for decor slots (snack posters use meshUvBbox semantics that fight rotation)', () => {
+      expect(slotSupportsOrientationFlip(slotById('signSnackPosterJerky'))).toBe(false)
+    })
+  })
+
+  describe('vanillaContentRotation classification (smoke check)', () => {
+    it('marks the 10 known-rotated picture frames with the right direction', () => {
+      const expected: Record<string, 'cw' | 'ccw'> = {
+        pictureFrame_01d: 'cw',
+        pictureFrame_01e: 'ccw',
+        pictureFrame_01f: 'ccw',
+        pictureFrame_01g: 'ccw',
+        pictureFrame_01h: 'ccw',
+        pictureFrame_01i: 'ccw',
+        pictureFrame_01j: 'ccw',
+        pictureFrame_01n: 'ccw',
+        pictureFrame_01q: 'ccw',
+        pictureFrame_01r: 'ccw',
+      }
+      for (const [slotId, direction] of Object.entries(expected)) {
+        expect(slotById(slotId).vanillaContentRotation,
+          `expected ${slotId} to be ${direction}`).toBe(direction)
+      }
+    })
+
+    it('leaves the 13 upright picture frames without a rotation marker', () => {
+      const upright = ['a', 'b', 'c', 'k', 'l', 'm', 'o', 'p', 's', 't', 'u', 'v', 'w']
+      for (const letter of upright) {
+        const slotId = `pictureFrame_01${letter}`
+        expect(slotById(slotId).vanillaContentRotation,
+          `expected ${slotId} to be undefined`).toBeUndefined()
+      }
+    })
   })
 })

--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -82,6 +82,25 @@ export interface SlotDef {
    */
   meshUvBbox?: MeshUvBbox
   /**
+   * Direction the VANILLA art was rotated 90° to fit the atlasTile rect.
+   *
+   * Some 7DTD picture-frame blocks have a portrait atlasTile but the
+   * vanilla artwork inside is landscape photography that the artist
+   * rotated 90° to fit. Users uploading landscape source content want
+   * the same visual outcome ~ the upload UI should default to a
+   * landscape drop zone, and the composer should rotate the user's
+   * cropped image the same direction the vanilla was rotated, before
+   * painting into the (still portrait) atlasTile.
+   *
+   * Undefined means the vanilla content reads correctly oriented
+   * relative to the atlasTile aspect ~ no rotation involved.
+   *
+   * Source of truth: scripts/fix_rotated_frame_thumbs.py (the ROTATIONS
+   * dict). When that script grows new entries, mirror them here so the
+   * runtime behavior stays in sync with the visual thumb fix.
+   */
+  vanillaContentRotation?: 'cw' | 'ccw'
+  /**
    * Optional caveat shown to users in the slot card header. Use for slots
    * where the vanilla art is misleading ~ e.g. a snack poster tile that
    * actually contains multiple stacked product designs in one block. Keep
@@ -89,6 +108,9 @@ export interface SlotDef {
    */
   note?: string
 }
+
+/** User's chosen upload orientation for a slot. */
+export type SlotOrientation = 'portrait' | 'landscape'
 
 /** Map a shared-atlas materialName to its base atlas image + dimensions. */
 export interface AtlasSource {
@@ -250,21 +272,21 @@ export const SLOTS: SlotDef[] = [
   { slotId: 'pictureFrame_01a', materialName: 'pictureFramed',  label: 'Frame A', vanillaBlocks: ['pictureFrame_01a'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
   { slotId: 'pictureFrame_01b', materialName: 'pictureFramed',  label: 'Frame B', vanillaBlocks: ['pictureFrame_01b'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
   { slotId: 'pictureFrame_01c', materialName: 'pictureFramed',  label: 'Frame C', vanillaBlocks: ['pictureFrame_01c'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
-  { slotId: 'pictureFrame_01d', materialName: 'pictureFramed2', label: 'Frame D', vanillaBlocks: ['pictureFrame_01d'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
-  { slotId: 'pictureFrame_01e', materialName: 'pictureFramed2', label: 'Frame E', vanillaBlocks: ['pictureFrame_01e'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
-  { slotId: 'pictureFrame_01f', materialName: 'pictureFramed2', label: 'Frame F', vanillaBlocks: ['pictureFrame_01f'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
-  { slotId: 'pictureFrame_01g', materialName: 'pictureFramed3', label: 'Frame G', vanillaBlocks: ['pictureFrame_01g'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
-  { slotId: 'pictureFrame_01h', materialName: 'pictureFramed3', label: 'Frame H', vanillaBlocks: ['pictureFrame_01h'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
-  { slotId: 'pictureFrame_01i', materialName: 'pictureFramed3', label: 'Frame I', vanillaBlocks: ['pictureFrame_01i'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
-  { slotId: 'pictureFrame_01j', materialName: 'pictureFramed4', label: 'Frame J', vanillaBlocks: ['pictureFrame_01j'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
+  { slotId: 'pictureFrame_01d', materialName: 'pictureFramed2', label: 'Frame D', vanillaBlocks: ['pictureFrame_01d'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 }, vanillaContentRotation: 'cw' },
+  { slotId: 'pictureFrame_01e', materialName: 'pictureFramed2', label: 'Frame E', vanillaBlocks: ['pictureFrame_01e'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 }, vanillaContentRotation: 'ccw' },
+  { slotId: 'pictureFrame_01f', materialName: 'pictureFramed2', label: 'Frame F', vanillaBlocks: ['pictureFrame_01f'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 }, vanillaContentRotation: 'ccw' },
+  { slotId: 'pictureFrame_01g', materialName: 'pictureFramed3', label: 'Frame G', vanillaBlocks: ['pictureFrame_01g'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 }, vanillaContentRotation: 'ccw' },
+  { slotId: 'pictureFrame_01h', materialName: 'pictureFramed3', label: 'Frame H', vanillaBlocks: ['pictureFrame_01h'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 }, vanillaContentRotation: 'ccw' },
+  { slotId: 'pictureFrame_01i', materialName: 'pictureFramed3', label: 'Frame I', vanillaBlocks: ['pictureFrame_01i'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 }, vanillaContentRotation: 'ccw' },
+  { slotId: 'pictureFrame_01j', materialName: 'pictureFramed4', label: 'Frame J', vanillaBlocks: ['pictureFrame_01j'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 }, vanillaContentRotation: 'ccw' },
   { slotId: 'pictureFrame_01k', materialName: 'pictureFramed4', label: 'Frame K', vanillaBlocks: ['pictureFrame_01k'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
   { slotId: 'pictureFrame_01l', materialName: 'pictureFramed4', label: 'Frame L', vanillaBlocks: ['pictureFrame_01l'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
   { slotId: 'pictureFrame_01m', materialName: 'pictureFramed5', label: 'Frame M', vanillaBlocks: ['pictureFrame_01m'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
-  { slotId: 'pictureFrame_01n', materialName: 'pictureFramed5', label: 'Frame N', vanillaBlocks: ['pictureFrame_01n'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
+  { slotId: 'pictureFrame_01n', materialName: 'pictureFramed5', label: 'Frame N', vanillaBlocks: ['pictureFrame_01n'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 }, vanillaContentRotation: 'ccw' },
   { slotId: 'pictureFrame_01o', materialName: 'pictureFramed5', label: 'Frame O', vanillaBlocks: ['pictureFrame_01o'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
   { slotId: 'pictureFrame_01p', materialName: 'pictureFramed6', label: 'Frame P', vanillaBlocks: ['pictureFrame_01p'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
-  { slotId: 'pictureFrame_01q', materialName: 'pictureFramed6', label: 'Frame Q', vanillaBlocks: ['pictureFrame_01q'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
-  { slotId: 'pictureFrame_01r', materialName: 'pictureFramed6', label: 'Frame R', vanillaBlocks: ['pictureFrame_01r'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
+  { slotId: 'pictureFrame_01q', materialName: 'pictureFramed6', label: 'Frame Q', vanillaBlocks: ['pictureFrame_01q'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 }, vanillaContentRotation: 'ccw' },
+  { slotId: 'pictureFrame_01r', materialName: 'pictureFramed6', label: 'Frame R', vanillaBlocks: ['pictureFrame_01r'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 }, vanillaContentRotation: 'ccw' },
   { slotId: 'pictureFrame_01s', materialName: 'pictureFramed7', label: 'Frame S', vanillaBlocks: ['pictureFrame_01s'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
   { slotId: 'pictureFrame_01t', materialName: 'pictureFramed7', label: 'Frame T', vanillaBlocks: ['pictureFrame_01t'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
   { slotId: 'pictureFrame_01u', materialName: 'pictureFramed7', label: 'Frame U', vanillaBlocks: ['pictureFrame_01u'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
@@ -312,6 +334,70 @@ export interface SlotState {
    * title are both searchable in the in-game creative search.
    */
   title?: string
+  /**
+   * User's chosen upload orientation. Only meaningful for slots whose
+   * effective shape can flip (currently canvasTile + moviePoster).
+   * Undefined falls back to the slot's default orientation (derived from
+   * atlasTile aspect + vanillaContentRotation).
+   */
+  orientation?: SlotOrientation
+}
+
+/**
+ * The slot's "natural" upload orientation ~ what the user would intuitively
+ * upload BEFORE any flip. For un-rotated vanilla content, that's the
+ * atlasTile's native aspect. For rotated vanilla content, it's the OPPOSITE
+ * (the artist's source orientation, before they tilted to fit the frame).
+ */
+export function getSlotDefaultOrientation(slot: SlotDef): SlotOrientation {
+  if (!slot.atlasTile) {
+    // Slots without atlasTile (portrait, abstract) ~ stick to portrait by
+    // convention; toggle isn't currently exposed for these kinds anyway.
+    return 'portrait'
+  }
+  const tileIsPortrait = slot.atlasTile.h > slot.atlasTile.w
+  if (slot.vanillaContentRotation) {
+    return tileIsPortrait ? 'landscape' : 'portrait'
+  }
+  return tileIsPortrait ? 'portrait' : 'landscape'
+}
+
+/** Whether this slot kind exposes the orientation flip toggle. */
+export function slotSupportsOrientationFlip(slot: SlotDef): boolean {
+  // canvasTile (picture frames + picture canvases) and moviePoster slots
+  // route through composeAtlas, where rotation can be applied cleanly
+  // before painting into the atlasTile rect. Portrait slots have a
+  // baked-in left-25%-wood / right-75%-canvas UV split that doesn't
+  // survive a 90° rotation, so they're excluded for now. Abstract and
+  // decor (snack posters etc.) have other constraints (UV bbox
+  // semantics, square defaults) that aren't worth flipping by default.
+  return slot.kind === 'canvasTile' || slot.kind === 'moviePoster'
+}
+
+/** Effective orientation = user's choice if set, else slot default. */
+export function getEffectiveOrientation(slot: SlotDef, state: SlotState): SlotOrientation {
+  if (state.orientation && slotSupportsOrientationFlip(slot)) return state.orientation
+  return getSlotDefaultOrientation(slot)
+}
+
+/**
+ * If the user's chosen orientation differs from the atlasTile's native
+ * aspect, the composer needs to rotate the input image 90° before
+ * painting it into the atlasTile rect. Direction matches the slot's
+ * vanillaContentRotation when present (so a flipped upload looks visually
+ * consistent with vanilla); CCW as the default for slots with no recorded
+ * vanilla rotation but whose user just toggled to the opposite aspect.
+ */
+export function getCompositeRotation(
+  slot: SlotDef,
+  state: SlotState,
+): 'cw' | 'ccw' | undefined {
+  if (!slot.atlasTile) return undefined
+  const orient = getEffectiveOrientation(slot, state)
+  const tileIsPortrait = slot.atlasTile.h > slot.atlasTile.w
+  const userIsPortrait = orient === 'portrait'
+  if (tileIsPortrait === userIsPortrait) return undefined
+  return slot.vanillaContentRotation ?? 'ccw'
 }
 
 export interface FramePreset {

--- a/src/utils/buildModlet.ts
+++ b/src/utils/buildModlet.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_FRAME_PRESET_ID,
   ATLAS_SOURCES,
   FRAME_PRESETS,
+  getCompositeRotation,
   type SlotState,
   type PackMeta,
   type SlotDef,
@@ -125,6 +126,10 @@ export async function buildModlet(
     const atlasBlob = await composeAtlas(materialName, group.map(p => ({
       tile: p.slot.atlasTile!,
       file: p.state.file!,
+      // If the slot's effective orientation is opposite the atlasTile's
+      // native aspect, rotate the user image 90° before painting so the
+      // composition matches the user's chosen orientation in-game.
+      rotation: getCompositeRotation(p.slot, p.state),
     })), frameTint)
     const filename = `${materialName}.png`
     root.file(`Resources/Textures/${filename}`, atlasBlob)

--- a/src/utils/composer.ts
+++ b/src/utils/composer.ts
@@ -23,6 +23,29 @@ import {
   type MeshUvBbox,
 } from '../types/slots'
 
+/** Rotate an HTMLImageElement-or-canvas-source 90° in the named direction.
+ *  Returns a fresh HTMLCanvasElement (drop-in for drawImage). */
+function rotate90(
+  source: HTMLImageElement | HTMLCanvasElement,
+  direction: 'cw' | 'ccw',
+): HTMLCanvasElement {
+  const sw = (source as HTMLImageElement).naturalWidth || (source as HTMLCanvasElement).width
+  const sh = (source as HTMLImageElement).naturalHeight || (source as HTMLCanvasElement).height
+  const out = document.createElement('canvas')
+  // Rotation swaps width and height ~ portrait becomes landscape and vice versa.
+  out.width = sh
+  out.height = sw
+  const ctx = out.getContext('2d')
+  if (!ctx) throw new Error('Canvas 2d context unavailable')
+  // Translate to the new center, rotate, then draw the source centered.
+  ctx.save()
+  ctx.translate(out.width / 2, out.height / 2)
+  ctx.rotate(direction === 'cw' ? Math.PI / 2 : -Math.PI / 2)
+  ctx.drawImage(source as CanvasImageSource, -sw / 2, -sh / 2, sw, sh)
+  ctx.restore()
+  return out
+}
+
 const PORTRAIT_W = 1024
 const PORTRAIT_H = 1024
 const FRAME_PCT = 0.25 // left 25% is the frame UV zone
@@ -203,7 +226,7 @@ export async function composeUvBboxFitted(file: File, bbox: MeshUvBbox): Promise
  */
 export async function composeAtlas(
   materialName: string,
-  entries: { tile: AtlasTile; file: File }[],
+  entries: { tile: AtlasTile; file: File; rotation?: 'cw' | 'ccw' }[],
   frameTint?: string,
 ): Promise<Blob> {
   const source = ATLAS_SOURCES[materialName]
@@ -236,13 +259,21 @@ export async function composeAtlas(
   //    bleed absorbs in-game mesh UV overshoot at the tile boundary so the
   //    mesh never samples vanilla wood-zone content (which otherwise shows
   //    as gray strips at the print's edges).
-  for (const { tile, file } of entries) {
+  //
+  //    If the entry has a rotation directive, we rotate the user's image
+  //    90° (in the indicated direction) BEFORE the cover-fit. That's how
+  //    a user-uploaded landscape image gets tilted to fit a portrait
+  //    atlasTile (or vice versa) when the slot's effective orientation
+  //    differs from the atlasTile's native aspect.
+  for (const { tile, file, rotation } of entries) {
     const img = await loadImage(file)
+    const sourceForPaint: HTMLImageElement | HTMLCanvasElement =
+      rotation ? rotate90(img, rotation) : img
     const bx = Math.max(0, tile.x - TILE_BLEED_PX)
     const by = Math.max(0, tile.y - TILE_BLEED_PX)
     const br = Math.min(source.size, tile.x + tile.w + TILE_BLEED_PX)
     const bb = Math.min(source.size, tile.y + tile.h + TILE_BLEED_PX)
-    drawCover(ctx, img, bx, by, br - bx, bb - by)
+    drawCover(ctx, sourceForPaint, bx, by, br - bx, bb - by)
   }
 
   return canvasToBlob(canvas)
@@ -267,26 +298,31 @@ export async function composeIcon(
 }
 
 // Object-fit: cover semantics. Scales the source image to entirely fill the
-// destination rect, cropping from center on the over-extending axis.
+// destination rect, cropping from center on the over-extending axis. Accepts
+// HTMLImageElement OR HTMLCanvasElement (both expose width/height + are
+// drawImage-compatible) so callers can hand us a rotated canvas without
+// having to round-trip through an intermediate image element.
 function drawCover(
   ctx: CanvasRenderingContext2D,
-  img: HTMLImageElement,
+  img: HTMLImageElement | HTMLCanvasElement,
   dx: number,
   dy: number,
   dw: number,
   dh: number,
 ) {
-  const srcRatio = img.width / img.height
+  const srcW = (img as HTMLImageElement).naturalWidth || (img as HTMLCanvasElement).width
+  const srcH = (img as HTMLImageElement).naturalHeight || (img as HTMLCanvasElement).height
+  const srcRatio = srcW / srcH
   const dstRatio = dw / dh
-  let sx = 0, sy = 0, sw = img.width, sh = img.height
+  let sx = 0, sy = 0, sw = srcW, sh = srcH
   if (srcRatio > dstRatio) {
     // src wider ~ crop sides
-    sw = img.height * dstRatio
-    sx = (img.width - sw) / 2
+    sw = srcH * dstRatio
+    sx = (srcW - sw) / 2
   } else if (srcRatio < dstRatio) {
     // src taller ~ crop top/bottom
-    sh = img.width / dstRatio
-    sy = (img.height - sh) / 2
+    sh = srcW / dstRatio
+    sy = (srcH - sh) / 2
   }
   ctx.drawImage(img, sx, sy, sw, sh, dx, dy, dw, dh)
 }

--- a/src/utils/livePreview.ts
+++ b/src/utils/livePreview.ts
@@ -34,6 +34,7 @@ import {
   DEFAULT_FRAME_PRESET_ID,
   type SlotDef,
   type FramePreset,
+  type SlotOrientation,
 } from '../types/slots'
 import { composeAtlas } from './composer'
 
@@ -199,7 +200,15 @@ export async function drawSlotPreviewInto(
   slot: SlotDef,
   framePresetId: string | undefined,
   file: File | undefined,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _orientation?: SlotOrientation,
 ): Promise<HTMLCanvasElement> {
+  // The orientation argument is currently informational ~ the canvas's
+  // backing-store dimensions are sized by the caller (see SlotCard's
+  // previewBackingSize), so the wood-frame border + cover-fit math here
+  // already shape themselves to whatever aspect the canvas has. We accept
+  // the param so the caller can drive useEffect dependencies cleanly,
+  // and so future preview-side rotation tricks have a place to land.
   const ctx = canvas.getContext('2d')
   if (!ctx) return canvas
 


### PR DESCRIPTION
## Summary

Closes the loop on the v1.0.2 thumb fix. After PR #15 the slot-card header thumbs read correctly upright, but Frame D/E/F (and 7 other rotated picture-frame slots) still asked users to upload portrait when their vanilla content is actually landscape. Drop zone + crop dialog + live preview now match the slot's true content orientation, with a Vertical/Horizontal toggle for explicit override.

## What changes

- **`SlotDef.vanillaContentRotation: 'cw' | 'ccw'`** baked in for the 10 picture-frame slots whose vanilla art was tilted to fit a portrait block. (Same classification as PR #15's `ROTATIONS` dict.)
- **`SlotState.orientation: 'portrait' | 'landscape'`** for the user's explicit choice. Falls back to a slot-derived default when undefined.
- **Drop zone + cropper aspect** follow the effective orientation.
- **`composer.composeAtlas` accepts a per-entry `rotation` directive.** `buildModlet` computes rotation from `(atlasTile orientation) XOR (effective user orientation)` and passes it through. A landscape upload to Frame E gets tilted CCW (matching vanilla's direction) into the still-portrait atlasTile rect.
- **`OrientationToggle` UI** on flippable slots (canvasTile + moviePoster). Highlights the slot's vanilla-matching default; persists user override via localStorage.

## Test plan

- [ ] Open the picture-frames tab → Frame D/E/F drop zones now landscape by default; A/B/C still portrait
- [ ] Upload a landscape image to Frame E with default orientation → live preview shows landscape, build modlet, install in V2.6, verify the in-game frame displays the rotated landscape style (matching vanilla)
- [ ] Toggle Frame E to Vertical → drop zone reshapes to portrait; upload portrait; verify in-game appears upright portrait (no rotation in composer)
- [ ] Reload the page → orientation toggle remembers your choice
- [ ] Picture canvases (atlasTile already landscape) → default landscape, no change in behavior unless user toggles
- [ ] Movie posters → default portrait, toggle available but rarely useful (vanilla art is always portrait)
- [ ] Backer portraits → no toggle (kind=portrait excluded)

## Tests

21 new vitest cases under `slots.test.ts` covering:
- `getSlotDefaultOrientation` for all 4 categories (upright frame, rotated frame, picture canvas, movie poster)
- `getEffectiveOrientation` honoring user choice + ignoring it on non-flippable kinds
- `getCompositeRotation` returning the right direction for the CCW + CW outlier cases
- `slotSupportsOrientationFlip` accepting canvasTile/moviePoster, rejecting portrait/abstract/decor
- Classification smoke check: the 10 rotated picture-frame slots have the right `vanillaContentRotation` direction; the 13 upright ones are undefined

64/64 tests passing.

## Out of scope (intentional)

- **Portrait slots** (backer paintings) — their composer has a baked-in left-25%-wood / right-75%-canvas UV split that doesn't survive a 90° rotation. Worth its own PR if requested.
- **Abstract / decor slots** — different aspect semantics that don't benefit from a flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)