### PR TITLE
v1.0.4: serve DIY kit from GitHub Releases

### DIFF
--- a/.github/workflows/release-diy-kit.yml
+++ b/.github/workflows/release-diy-kit.yml
@@ -1,0 +1,63 @@
+name: Attach DIY kit to release
+
+# Fires when a GitHub Release is published (e.g. via `gh release create vX.Y.Z`).
+# Builds the DIY kit zip from the tagged source and uploads it as a release
+# asset. The landing page's "DIY Kit (offline)" button points at the
+# /releases/latest/download/KitsunePrints-DIY-Kit.zip pattern, which GitHub
+# auto-redirects to whichever the latest release is ~ so as soon as this
+# workflow finishes, the new release's kit is what users get.
+
+on:
+  release:
+    types: [published]
+  # Manual fallback: re-upload to a specific release if the release-time run
+  # failed or if you cut a release before adding this workflow.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach to (e.g. v1.0.4)'
+        required: true
+        type: string
+
+jobs:
+  attach-kit:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # required for gh release upload to write back to the release
+    steps:
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Pillow (for DIY kit builder)
+        run: pip install Pillow
+
+      - name: Build DIY kit zip
+        # Reads sources from the checked-out tag and writes
+        # public/KitsunePrints-DIY-Kit.zip ~ same script the live deploy
+        # uses, just running here against the tagged tree.
+        run: python scripts/build_diy_kit.py
+
+      - name: Upload kit to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # `--clobber` so re-running this workflow against an existing release
+        # replaces the asset rather than failing on duplicate.
+        run: |
+          gh release upload "${{ steps.tag.outputs.tag }}" \
+            public/KitsunePrints-DIY-Kit.zip \
+            --clobber \
+            --repo "${{ github.repository }}"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <p align="center">
   <a href="https://prints.kitsuneden.net"><img src="https://img.shields.io/badge/Live-prints.kitsuneden.net-fb923c?style=for-the-badge" alt="Live site" /></a>
   <a href="https://prints.kitsuneden.net/app"><img src="https://img.shields.io/badge/Build_a_Pack-Web_Tool-zinc?style=for-the-badge&color=18181b" alt="Web tool" /></a>
-  <a href="https://prints.kitsuneden.net/KitsunePrints-DIY-Kit.zip"><img src="https://img.shields.io/badge/DIY_Kit-Offline-zinc?style=for-the-badge&color=27272a" alt="DIY kit download" /></a>
+  <a href="https://github.com/Kitsune-Den/KitsunePrints/releases/latest/download/KitsunePrints-DIY-Kit.zip"><img src="https://img.shields.io/badge/DIY_Kit-Offline-zinc?style=for-the-badge&color=27272a" alt="DIY kit download" /></a>
   <a href="https://paint.kitsuneden.net"><img src="https://img.shields.io/badge/Sister_Tool-KitsunePaint-zinc?style=for-the-badge&color=27272a" alt="KitsunePaint" /></a>
 </p>
 
@@ -80,7 +80,7 @@ Result: one composite texture file per shared material, with each prefab automat
 
 ## DIY / offline
 
-If you'd rather skip the web tool, grab [`KitsunePrints-DIY-Kit.zip`](https://prints.kitsuneden.net/KitsunePrints-DIY-Kit.zip) ~ Python script + DLL + frame textures + 11 vanilla atlases (~46 MB unzipped) + example config. `pip install Pillow`, edit a JSON, drop your images, run `python make_pack.py example_pack/`, get a modlet out. The DIY kit ships every category the web tool ships ~ same 69 slots, same atlas-tile compositing, same press-E pickup.
+If you'd rather skip the web tool, grab [`KitsunePrints-DIY-Kit.zip`](https://github.com/Kitsune-Den/KitsunePrints/releases/latest/download/KitsunePrints-DIY-Kit.zip) from GitHub Releases ~ Python script + DLL + frame textures + 11 vanilla atlases (~46 MB unzipped) + example config. `pip install Pillow`, edit a JSON, drop your images, run `python make_pack.py example_pack/`, get a modlet out. The DIY kit ships every category the web tool ships ~ same 69 slots, same atlas-tile compositing, same press-E pickup.
 
 ## Dependencies
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kitsuneprints",
   "private": true,
-  "version": "1.0.3",
+  "version": "1.0.4",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/IntroPage.tsx
+++ b/src/pages/IntroPage.tsx
@@ -164,9 +164,9 @@ export default function IntroPage() {
             <span className="ml-2 group-hover:translate-x-1 inline-block transition-transform">→</span>
           </a>
           <a
-            href="/KitsunePrints-DIY-Kit.zip"
+            href="https://github.com/Kitsune-Den/KitsunePrints/releases/latest/download/KitsunePrints-DIY-Kit.zip"
             className="px-8 py-4 border border-zinc-700 hover:border-orange-500 hover:text-orange-300 text-zinc-400 text-sm font-medium tracking-widest uppercase rounded-lg transition-all duration-200"
-            title="Offline kit ~ Python script + DLL + frame textures, build packs locally"
+            title="Offline kit ~ Python script + DLL + frame textures, build packs locally. Hosted on GitHub Releases (always the latest version)."
           >
             DIY Kit (offline)
           </a>


### PR DESCRIPTION
## Summary

The DIY Kit (offline) button on the landing page now downloads from GitHub Releases instead of `/KitsunePrints-DIY-Kit.zip` on the live site.

## Why

1. **Versioned + archived per tag.** Users who want an older kit can grab v1.0.2's release instead of always getting whatever's currently deployed.
2. **Live site stops shipping a 60 MB blob it doesn't need to.** Saves rsync time per deploy + ~60 MB on the VPS.
3. **Single source of truth for releases.** GitHub already hosts the source, the changelog, the binary releases — kit fits there too.

## Changes

- **`src/pages/IntroPage.tsx`** — DIY Kit button href → `https://github.com/Kitsune-Den/KitsunePrints/releases/latest/download/KitsunePrints-DIY-Kit.zip`. GitHub auto-redirects `/latest/download/<asset>` to whatever the latest release's matching asset is, so the link stays valid forever.
- **`README.md`** — DIY kit badge + body link both point at the same URL.
- **`.github/workflows/release-diy-kit.yml`** — new workflow that fires on `release.published`, checks out the tagged source, builds the kit, and uploads it via `gh release upload --clobber`. v1.0.3's kit was uploaded manually as a one-time backfill; v1.0.4+ goes through this workflow automatically when I `gh release create`. `workflow_dispatch` input lets us re-attach to an arbitrary older tag if a release-time run ever fails.

## Not removed (deliberately)

`deploy.yml` still builds `public/KitsunePrints-DIY-Kit.zip` and ships it with the site. Kept as a fallback for any existing bookmarks or external links pointing at the `prints.kitsuneden.net` URL. Worth removing in a future PR once we've confirmed nothing relies on it.

## Test plan

- [ ] Click DIY Kit button on the live landing page after deploy → confirm it lands on a GitHub Releases download
- [ ] On v1.0.4 release creation: confirm `release-diy-kit.yml` workflow fires, builds, uploads
- [ ] `gh release view v1.0.4 --json assets --jq '.assets[].name'` includes `KitsunePrints-DIY-Kit.zip`
- [ ] `https://github.com/Kitsune-Den/KitsunePrints/releases/latest/download/KitsunePrints-DIY-Kit.zip` resolves with HTTP 200 + non-zero content-length

🤖 Generated with [Claude Code](https://claude.com/claude-code)