### PR TITLE
v1.0.6: fix Frame D upside-down rotation direction

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kitsuneprints",
   "private": true,
-  "version": "1.0.5",
+  "version": "1.0.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/types/slots.test.ts
+++ b/src/types/slots.test.ts
@@ -58,10 +58,13 @@ describe('orientation helpers', () => {
       expect(getSlotDefaultOrientation(slotById('pictureFrame_01e'))).toBe('landscape')
     })
 
-    it('returns landscape for the CW outlier (pictureFrame_01d, bear)', () => {
-      // 01d's vanilla was rotated CW (the lone outlier among rotated frames).
-      // Default is still landscape ~ direction doesn't change which orientation
-      // the user starts from, only the eventual rotation when compositing.
+    it('returns landscape for the bear frame (pictureFrame_01d)', () => {
+      // v1.0.3 originally classified 01d as the CW outlier; v1.0.6 corrected
+      // that to CCW after a user-reported upside-down render in-game (Frame
+      // D was the only one visibly affected, confirming D's vanilla rotation
+      // matches the other rotated slots, not the opposite). The default
+      // orientation is still landscape ~ direction never affected which
+      // orientation the user starts from, only the eventual composite rotation.
       expect(getSlotDefaultOrientation(slotById('pictureFrame_01d'))).toBe('landscape')
     })
 
@@ -116,9 +119,9 @@ describe('orientation helpers', () => {
       expect(getCompositeRotation(s, {})).toBe('ccw')
     })
 
-    it('returns the slot vanillaContentRotation for the CW outlier (pictureFrame_01d)', () => {
+    it('returns CCW for the bear frame (pictureFrame_01d) ~ same as the other 9 rotated slots post-v1.0.6', () => {
       const s = slotById('pictureFrame_01d')
-      expect(getCompositeRotation(s, {})).toBe('cw')
+      expect(getCompositeRotation(s, {})).toBe('ccw')
     })
 
     it('returns undefined when user toggles back to portrait on a rotated-default slot', () => {
@@ -158,22 +161,16 @@ describe('orientation helpers', () => {
   })
 
   describe('vanillaContentRotation classification (smoke check)', () => {
-    it('marks the 10 known-rotated picture frames with the right direction', () => {
-      const expected: Record<string, 'cw' | 'ccw'> = {
-        pictureFrame_01d: 'cw',
-        pictureFrame_01e: 'ccw',
-        pictureFrame_01f: 'ccw',
-        pictureFrame_01g: 'ccw',
-        pictureFrame_01h: 'ccw',
-        pictureFrame_01i: 'ccw',
-        pictureFrame_01j: 'ccw',
-        pictureFrame_01n: 'ccw',
-        pictureFrame_01q: 'ccw',
-        pictureFrame_01r: 'ccw',
-      }
-      for (const [slotId, direction] of Object.entries(expected)) {
+    it('marks all 10 known-rotated picture frames as CCW', () => {
+      // v1.0.3 originally split D off as a CW outlier based on a thumb-fix
+      // direction that turned out to mean something different than the
+      // composite rotation direction. v1.0.6 brought D in line with the
+      // other 9 after user-confirmed in-game upside-down render on D only.
+      const rotated = ['d', 'e', 'f', 'g', 'h', 'i', 'j', 'n', 'q', 'r']
+      for (const letter of rotated) {
+        const slotId = `pictureFrame_01${letter}`
         expect(slotById(slotId).vanillaContentRotation,
-          `expected ${slotId} to be ${direction}`).toBe(direction)
+          `expected ${slotId} to be ccw`).toBe('ccw')
       }
     })
 

--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -272,7 +272,7 @@ export const SLOTS: SlotDef[] = [
   { slotId: 'pictureFrame_01a', materialName: 'pictureFramed',  label: 'Frame A', vanillaBlocks: ['pictureFrame_01a'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 } },
   { slotId: 'pictureFrame_01b', materialName: 'pictureFramed',  label: 'Frame B', vanillaBlocks: ['pictureFrame_01b'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 } },
   { slotId: 'pictureFrame_01c', materialName: 'pictureFramed',  label: 'Frame C', vanillaBlocks: ['pictureFrame_01c'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 } },
-  { slotId: 'pictureFrame_01d', materialName: 'pictureFramed2', label: 'Frame D', vanillaBlocks: ['pictureFrame_01d'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 }, vanillaContentRotation: 'cw' },
+  { slotId: 'pictureFrame_01d', materialName: 'pictureFramed2', label: 'Frame D', vanillaBlocks: ['pictureFrame_01d'], kind: 'canvasTile', atlasTile: { x: 1288, y: 1138, w: 735, h: 898 }, vanillaContentRotation: 'ccw' },
   { slotId: 'pictureFrame_01e', materialName: 'pictureFramed2', label: 'Frame E', vanillaBlocks: ['pictureFrame_01e'], kind: 'canvasTile', atlasTile: { x: 373,  y: 1533, w: 350, h: 502 }, vanillaContentRotation: 'ccw' },
   { slotId: 'pictureFrame_01f', materialName: 'pictureFramed2', label: 'Frame F', vanillaBlocks: ['pictureFrame_01f'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 }, vanillaContentRotation: 'ccw' },
   { slotId: 'pictureFrame_01g', materialName: 'pictureFramed3', label: 'Frame G', vanillaBlocks: ['pictureFrame_01g'], kind: 'canvasTile', atlasTile: { x: 741,  y: 1361, w: 532, h: 674 }, vanillaContentRotation: 'ccw' },


### PR DESCRIPTION
## Summary

User report: landscape images uploaded to Frame D were rendering upside down in V2.6 POIs. The other 9 rotated picture-frame slots (E/F/G/H/I/J/N/Q/R) were correct.

## Root cause

In v1.0.3 I classified Frame D as the lone CW outlier based on the direction the thumb-fix script (PR #15) used to make the bear thumb readable in the slot card. That direction is "the rotation we apply to **un-do** the vanilla artist's tilt" — opposite of "the rotation we apply when re-tilting user-uploaded landscape to **match** vanilla's tilted style in-game."

For the 9 slots that mismatch produced no visible bug (rotational symmetry + scene content masked any subtle drift). For Frame D the bear's clear "head/paws" cue made the 180° error obvious.

## Fix

Single-character change in `slots.ts`:

```diff
- pictureFrame_01d: vanillaContentRotation: 'cw'
+ pictureFrame_01d: vanillaContentRotation: 'ccw'
```

All 10 rotated picture-frame slots now share `'ccw'`. The smoke test simplified accordingly.

The `fix_rotated_frame_thumbs.py` script's per-slot directions are unchanged — those are about THUMB presentation (a different rotation concept than the composite). The `vanillaContentRotation` field doc remains accurate. Worth a future cleanup pass to clarify naming, but post-fix the runtime is correct on all 10 slots.

## Test plan

- [ ] Upload a landscape cat photo to Frame D, build pack, install → cat appears in vanilla's tilted style (matching how vanilla's bear renders), NOT upside down
- [ ] Quick spot-check on Frame E to confirm we didn't break the working slots
- [ ] 64/64 vitest passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)