### PR TITLE
v1.0.7: vanilla block rename (Working Stiff Calendar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kitsuneprints",
   "private": true,
-  "version": "1.0.6",
+  "version": "1.0.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/scripts/audit_pickup_candidates.py
+++ b/scripts/audit_pickup_candidates.py
@@ -93,7 +93,7 @@ ALREADY_COVERED = {
     "paintingAbstract03_2x2", "paintingAbstract03_3x2",
     "paintingAbstract04_2x2", "paintingAbstract04_3x2",
     # decor posters
-    "posterCalendarPinupWorkingStiff", "posterBlueprintPistol",
+    "posterCalendarWorkingStiff", "posterBlueprintPistol",
     "posterBlueprintRifle", "posterCat", "posterCats", "posterSparky",
     "targetPoster1", "targetPoster2",
     "signPosterWantedMissing01", "signPosterWantedMissing02", "signPosterWantedMissing03",

--- a/scripts/make_pack.py
+++ b/scripts/make_pack.py
@@ -125,8 +125,11 @@ SLOTS: list[tuple[str, str, list[str], str, Optional[tuple[int, int, int, int]],
      "moviePoster", (351, 518, 696, 1000), "posterMovie"),
 
     # --- Misc decor (5 standalone slots ~ each material gets its own texture) ---
+    # slotId + materialName stay under the old name (matches the DIY kit's
+    # internal references and the in-engine prefab); only vanillaBlocks
+    # follows the V 2.6 b14 rename that dropped "Pinup".
     ("posterCalendarPinupWorkingStiff", "Working Stiff Calendar",
-     ["posterCalendarPinupWorkingStiff"], "decor", None, "posterCalendarPinupWorkingStiff"),
+     ["posterCalendarWorkingStiff"], "decor", None, "posterCalendarPinupWorkingStiff"),
     ("gunBlueprintPistol", "Pistol Blueprint",
      ["posterBlueprintPistol"], "decor", None, "gunBlueprintPistol"),
     ("gunBlueprintRifle", "Rifle Blueprint",
@@ -238,7 +241,7 @@ PICKUP_BLOCKS = [
     "paintingAbstract03_2x2", "paintingAbstract03_3x2",
     "paintingAbstract04_2x2", "paintingAbstract04_3x2",
     # Misc decor posters
-    "posterCalendarPinupWorkingStiff", "posterBlueprintPistol", "posterBlueprintRifle",
+    "posterCalendarWorkingStiff", "posterBlueprintPistol", "posterBlueprintRifle",
     "posterCat", "posterCats", "posterSparky", "targetPoster1", "targetPoster2",
     "signPosterWantedMissing01", "signPosterWantedMissing02", "signPosterWantedMissing03",
     # Snack posters

--- a/src/types/slots.ts
+++ b/src/types/slots.ts
@@ -199,9 +199,18 @@ export const SLOTS: SlotDef[] = [
   // of the original atlas-half offset).
   {
     slotId: 'posterCalendarPinupWorkingStiff',
+    // materialName tracks the in-engine MATERIAL (which is bound to the
+    // prefab file `posterCalendarPinupWorkingStiffPrefab.prefab`); TFP
+    // kept the prefab/material name and only renamed the BLOCK declaration,
+    // so this stays under the old name to keep the DLL's material swap
+    // pointing at the right asset.
     materialName: 'posterCalendarPinupWorkingStiff',
     label: 'Working Stiff Calendar',
-    vanillaBlocks: ['posterCalendarPinupWorkingStiff'],
+    // BLOCK name was renamed in a V 2.6 b14 patch: TFP dropped "Pinup".
+    // Our XML pickup-append + extends reference must follow the new name
+    // or the patch silently no-ops (yellow warning) and the kp_* block
+    // never inherits properly.
+    vanillaBlocks: ['posterCalendarWorkingStiff'],
     kind: 'decor',
   },
   {

--- a/src/utils/pickupBlocks.ts
+++ b/src/utils/pickupBlocks.ts
@@ -29,7 +29,8 @@ export const PICKUP_BLOCKS: string[] = [
   'paintingAbstract04_2x2', 'paintingAbstract04_3x2',
 
   // --- Misc decor posters (12) ---
-  'posterCalendarPinupWorkingStiff',
+  'posterCalendarWorkingStiff', // V 2.6 b14 rename ~ was posterCalendarPinupWorkingStiff
+
   'posterBlueprintPistol',
   'posterBlueprintRifle',
   'posterCat',


### PR DESCRIPTION
## Summary

TFP renamed the Working Stiff Calendar block in a V 2.6 b14 patch — dropped "Pinup" from the block declaration name. Our XML pickup-append patches were targeting the old name, silently no-op'ing with a yellow warning at startup.

Caught while debugging a user-reported error flood (separate issue, environment-specific). Confirmed via:
- Their `output_log.txt` shows `Version: V 2.6 (b14)` — same target version we build for, so version mismatch ruled out
- Their vanilla `blocks.xml` lists `posterCalendarWorkingStiff` (no "Pinup")
- The prefab file `posterCalendarPinupWorkingStiffPrefab.prefab` kept the old name — so the in-engine MATERIAL name stays under "Pinup", only the block declaration moved

## Changes

| File | What |
|---|---|
| `src/types/slots.ts` | `vanillaBlocks` references new name; slotId + materialName intentionally kept under the old name for localStorage continuity + correct material lookup |
| `src/utils/pickupBlocks.ts` | pickup list updated |
| `scripts/make_pack.py` | DIY-kit Python path mirrors the same change |
| `scripts/audit_pickup_candidates.py` | dev-tool consistency |

## Test plan

- [ ] Build a pack with the Working Stiff Calendar slot filled, install, load a world → confirm the yellow `XML patch ... did not apply` warning is gone from `output_log.txt`
- [ ] Press E on the in-game calendar block → confirm pickup behavior works (means the `<append>` patch landed)
- [ ] 64/64 vitest still passing

## Not in this PR

V 2.6 b14 also added new vanilla blocks `posterCat`, `posterCats`, `posterSparky` that we don't target yet. They're in our `pickupBlocks` list (so they pickup when E-pressed), but no `SlotDef` entries exist. Worth a future PR if we want users to make custom prints for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)